### PR TITLE
Initial direct type wrappers (for c++)

### DIFF
--- a/gentype.py
+++ b/gentype.py
@@ -1,0 +1,29 @@
+def gen_named_tuple_type(name, **kwargs):
+    print("class {} {{".format(name))
+    print("private:")
+    count = 1
+    for key, value in kwargs.items():
+        # print("\tstatic const int size{} = TypeDetails<{}>::bytecount;".format(count, value))
+        print("\tstatic const int size{} = sizeof({});".format(count, value))
+        count += 1
+    total = count
+    print("\tuint8_t data[{}];".format(" + ".join(["size" + str(i) for i in range(1, total)])))
+    print("public:")
+    count = 1
+    for key, value in kwargs.items():
+        print("\t{}& {}() {{ return *({}*)(data{}{}); }}".format(
+            value,
+            key,
+            value,
+            (" + " if count > 1 else ""),
+            (" + ".join(["size" + str(i) for i in range(1, count)]) if count > 1 else "")
+        )
+        )
+        count += 1
+    print("};")
+    print()
+
+
+gen_named_tuple_type("NamedTupleBoolAndInt", X="int64_t", Y="float")
+gen_named_tuple_type("NamedTupleBoolIntStr", X="int64_t", Y="float", Z="str")
+gen_named_tuple_type("NamedTupleListAndTupleOfStr", items="ListOf<str>", elements="TupleOf<str>")

--- a/nativepython/tests/string_compilation_test.py
+++ b/nativepython/tests/string_compilation_test.py
@@ -44,17 +44,20 @@ def callOrExcept(f, *args):
     except Exception as e:
         return ("Exception", str(e))
 
+
 def callOrExceptType(f, *args):
     try:
         return ("Normal", f(*args))
     except Exception as e:
         return ("Exception", str(type(e)))
 
+
 def callOrExceptNoType(f, *args):
     try:
         return ("Normal", f(*args))
-    except Exception as e:
+    except Exception:
         return ("Exception", )
+
 
 class TestStringCompilation(unittest.TestCase):
     def test_string_passing_and_refcounting(self):
@@ -138,7 +141,6 @@ class TestStringCompilation(unittest.TestCase):
             s_from_code = f()
 
             self.assertEqual(s, s_from_code, (repr(s), repr(s_from_code)))
-
 
     def test_string_getitem(self):
         @Compiled
@@ -384,16 +386,16 @@ class TestStringCompilation(unittest.TestCase):
             self.assertEqual(result, baseline, "{} -> {}".format(s, result))
             result = callOrExceptNoType(c_split_initialized, s, ["a", "b", "c"])
             self.assertEqual(result, baseline, "{} -> {}".format(s, result))
-            for m in range(-2,10):
+            for m in range(-2, 10):
                 result = callOrExceptNoType(c_split_3max, s, m)
                 baseline = callOrExceptNoType(lambda: s.split(maxsplit=m))
                 self.assertEqual(result, baseline, "{},{}-> {}".format(s, m, result))
 
-            for sep in ["", "j", "s", "d" ,"t", " ", "as", "jks"]:
+            for sep in ["", "j", "s", "d", "t", " ", "as", "jks"]:
                 result = callOrExceptNoType(c_split_3, s, sep)
                 baseline = callOrExceptNoType(lambda: s.split(sep))
                 self.assertEqual(result, baseline, "{},{}-> {}".format(s, sep, result))
-                for m in range(-2,10):
+                for m in range(-2, 10):
                     result = callOrExceptNoType(c_split, s, sep, m)
                     baseline = callOrExceptNoType(lambda: s.split(sep, m))
                     self.assertEqual(result, baseline, "{},{},{}-> {}".format(s, sep, m, result))

--- a/nativepython/type_wrappers/runtime_functions.py
+++ b/nativepython/type_wrappers/runtime_functions.py
@@ -20,7 +20,6 @@ Int64 = native_ast.Int64
 Float64 = native_ast.Float64
 Void = native_ast.Void
 
-
 def externalCallTarget(name, output, *inputs):
     return native_ast.CallTarget.Named(
         target=native_ast.NamedCallTarget(
@@ -159,6 +158,30 @@ string_find_2 = externalCallTarget(
 string_find_3 = externalCallTarget(
     "nativepython_runtime_string_find_3",
     Int64,
+    Void.pointer(), Void.pointer(), Int64
+)
+
+string_split = externalCallTarget(
+    "nativepython_runtime_string_split",
+    Void,
+    Void.pointer(), Void.pointer(), Void.pointer(), Int64
+)
+
+string_split_2 = externalCallTarget(
+    "nativepython_runtime_string_split_2",
+    Void,
+    Void.pointer(), Void.pointer()
+)
+
+string_split_3 = externalCallTarget(
+    "nativepython_runtime_string_split_3",
+    Void,
+    Void.pointer(), Void.pointer(), Void.pointer()
+)
+
+string_split_3max = externalCallTarget(
+    "nativepython_runtime_string_split_3max",
+    Void,
     Void.pointer(), Void.pointer(), Int64
 )
 

--- a/nativepython/type_wrappers/runtime_functions.py
+++ b/nativepython/type_wrappers/runtime_functions.py
@@ -20,6 +20,7 @@ Int64 = native_ast.Int64
 Float64 = native_ast.Float64
 Void = native_ast.Void
 
+
 def externalCallTarget(name, output, *inputs):
     return native_ast.CallTarget.Named(
         target=native_ast.NamedCallTarget(

--- a/nativepython/type_wrappers/string_wrapper.py
+++ b/nativepython/type_wrappers/string_wrapper.py
@@ -13,13 +13,10 @@
 #   limitations under the License.
 
 from nativepython.type_wrappers.refcounted_wrapper import RefcountedWrapper
-from typed_python import Int64
-from typed_python import Bool
+from typed_python import Int64, Bool, String, NoneType
 
 import nativepython.type_wrappers.runtime_functions as runtime_functions
 from nativepython.type_wrappers.bound_compiled_method_wrapper import BoundCompiledMethodWrapper
-
-from typed_python import String
 
 import nativepython.native_ast as native_ast
 import nativepython
@@ -168,7 +165,7 @@ class StringWrapper(RefcountedWrapper):
     ])
 
     def convert_attribute(self, context, instance, attr):
-        if attr in ("find",) or attr in self._str_methods or attr in self._bool_methods:
+        if attr in ("find", "split") or attr in self._str_methods or attr in self._bool_methods:
             return instance.changeType(BoundCompiledMethodWrapper(self, attr))
 
         return super().convert_attribute(context, instance, attr)
@@ -228,6 +225,51 @@ class StringWrapper(RefcountedWrapper):
                             args[0].nonref_expr.cast(VoidPtr),
                             args[1].nonref_expr,
                             args[2].nonref_expr
+                        )
+                    )
+                )
+        elif methodname == "split":
+            if len(args) == 2:
+                return context.push(
+                    NoneType,
+                    lambda Ref: Ref.expr.store(
+                        runtime_functions.string_split_2.call(
+                            args[0].nonref_expr.cast(VoidPtr),
+                            args[1].nonref_expr.cast(VoidPtr)
+                        )
+                    )
+                )
+            elif len(args) == 3 and args[2].expr_type.typeRepresentation == String:
+                return context.push(
+                    NoneType,
+                    lambda Ref: Ref.expr.store(
+                        runtime_functions.string_split_3.call(
+                            args[0].nonref_expr.cast(VoidPtr),
+                            args[1].nonref_expr.cast(VoidPtr),
+                            args[2].nonref_expr.cast(VoidPtr)
+                        )
+                    )
+                )
+            elif len(args) == 3 and args[2].expr_type.typeRepresentation == Int64:
+                return context.push(
+                    NoneType,
+                    lambda Ref: Ref.expr.store(
+                        runtime_functions.string_split_3max.call(
+                            args[0].nonref_expr.cast(VoidPtr),
+                            args[1].nonref_expr.cast(VoidPtr),
+                            args[2].nonref_expr
+                        )
+                    )
+                )
+            elif len(args) == 4:
+                return context.push(
+                    NoneType,
+                    lambda Ref: Ref.expr.store(
+                        runtime_functions.string_split.call(
+                            args[0].nonref_expr.cast(VoidPtr),
+                            args[1].nonref_expr.cast(VoidPtr),
+                            args[2].nonref_expr.cast(VoidPtr),
+                            args[3].nonref_expr
                         )
                     )
                 )

--- a/typed_python/AllTypes.hpp
+++ b/typed_python/AllTypes.hpp
@@ -26,3 +26,4 @@
 #include "ClassType.hpp"
 #include "BoundMethodType.hpp"
 
+#include "DirectTypes.hpp"

--- a/typed_python/ConstDictType.cpp
+++ b/typed_python/ConstDictType.cpp
@@ -170,7 +170,7 @@ void ConstDict::addDicts(instance_ptr lhs, instance_ptr rhs, instance_ptr output
 }
 
 void ConstDict::subtractTupleOfKeysFromDict(instance_ptr lhs, instance_ptr rhs, instance_ptr output) const {
-    TupleOf* tupleType = tupleOfKeysType();
+    TupleOfType* tupleType = tupleOfKeysType();
 
     int64_t lhsCount = count(lhs);
     int64_t rhsCount = tupleType->count(rhs);

--- a/typed_python/ConstDictType.hpp
+++ b/typed_python/ConstDictType.hpp
@@ -75,8 +75,8 @@ public:
 
     void addDicts(instance_ptr lhs, instance_ptr rhs, instance_ptr output) const;
 
-    TupleOf* tupleOfKeysType() const {
-        return TupleOf::Make(m_key);
+    TupleOfType* tupleOfKeysType() const {
+        return TupleOfType::Make(m_key);
     }
 
     void subtractTupleOfKeysFromDict(instance_ptr lhs, instance_ptr rhs, instance_ptr output) const;

--- a/typed_python/DirectTypes.hpp
+++ b/typed_python/DirectTypes.hpp
@@ -1,0 +1,439 @@
+#pragma once
+
+#include "Type.hpp"
+
+/* usage:
+    str s("abc");
+    str t;
+    // perform String operations on mLayout
+    if (String::islower(s.mLayout))
+        ...
+    // can convert String::layout* to str
+    str a = str(StringConcat(s.mLayout, t.mLayout));
+
+*/
+/*
+template <class T>
+class DirectWrapper {
+    public:
+        T::layout* mLayout
+        static T* getType() {
+            static * t = T::Make();
+            return t;
+        }
+        DirectWrapper(T& s) {
+            mLayout = nullptr;
+        }
+        DirectWrapper(T::layout* l) {
+            mLayout = nullptr;
+        }
+        ~DirectWrapper() {
+            getType()->destroy((instance_ptr)&mLayout);
+        }
+        DirectWrapper(const DirectWrapper& other)
+        {
+	        getType()->copy_constructor(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&other.mLayout
+               );
+        }
+
+        DirectWrapper& operator=(const DirectWrapper& other)
+        {
+	        getType()->assign(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&other.mLayout
+               );
+            return *this;
+        }
+};
+typedef DirectWrapper<String> str;
+*/
+class str {
+    public:
+        String::layout* mLayout;
+        static String* getType() {
+            static String* t = String::Make();
+            return t;
+        }
+
+        str() {
+            mLayout = nullptr;
+        }
+
+        str(const char *pc) {
+            getType()->constructor((instance_ptr)&mLayout, 1, strlen(pc), pc);
+        }
+
+        str(std::string& s) {
+            getType()->constructor((instance_ptr)&mLayout, 1, s.length(), s.data());
+        }
+
+        str(String::layout* l) {
+	        getType()->assign(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&l
+               );
+        }
+
+        ~str() {
+            String::destroyStatic((instance_ptr)&mLayout);
+        }
+
+        str(const str& other)
+        {
+	        getType()->copy_constructor(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&other.mLayout
+               );
+        }
+
+        str& operator=(const str& other)
+        {
+	        getType()->assign(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&other.mLayout
+               );
+            return *this;
+        }
+
+        template<class buf_t>
+        void serialize(instance_ptr self, buf_t& buffer) {
+            getType()->serialize<buf_t>((instance_ptr)&mLayout, buffer);
+        }
+
+        template<class buf_t>
+        void deserialize(instance_ptr self, buf_t& buffer) {
+            getType()->serialize<buf_t>((instance_ptr)&mLayout, buffer);
+        }
+};
+
+template<class element_type>
+class TypeDetails {
+public:
+    static Type* getType() { throw std::runtime_error("specialize me");}
+    
+    static const uint64_t bytecount = 0;
+};
+
+template<>
+class TypeDetails<int64_t> {
+public:
+    static Type* getType() { return Int64::Make(); }
+
+    static const uint64_t bytecount = sizeof(int64_t);
+};
+
+template<>
+class TypeDetails<uint64_t> {
+public:
+    static Type* getType() { return UInt64::Make(); }
+
+    static const uint64_t bytecount = sizeof(uint64_t);
+};
+
+template<>
+class TypeDetails<bool> {
+public:
+    static Type* getType() { return Bool::Make(); }
+
+    static const uint64_t bytecount = sizeof(bool);
+};
+template<>
+class TypeDetails<double> {
+public:
+    static Type* getType() { return Float64::Make(); }
+
+    static const uint64_t bytecount = sizeof(double);
+};
+
+template<>
+class TypeDetails<float> {
+public:
+    static Type* getType() { return Float32::Make(); }
+
+    static const uint64_t bytecount = sizeof(float);
+};
+
+template<>
+class TypeDetails<str> {
+public:
+    static Type* getType() {
+        static Type* t = String::Make();
+        if (t->bytecount() != bytecount) {
+            throw std::runtime_error("somehow we have the wrong bytecount!");
+        }
+        return t;
+    }
+
+    static const uint64_t bytecount = sizeof(void*);
+};
+
+
+//templates for TupleOf, ListOf, Dict, ConstDict, OneOf
+template<class element_type>
+class ListOf {
+public:
+    static ListOfType* getType() {
+        static ListOfType* t = ListOfType::Make(TypeDetails<element_type>::getType());
+
+        return t;
+    }
+
+    //static ListOf<element_type> fromPython(PyObject* p) {
+        //pyInstance::copyConstructFromPythonInstance(Type* eltType, instance_ptr tgt, PyObject* pyRepresentation, bool isExplicit);
+    //}
+
+    element_type& operator[](int64_t offset) {
+       return *(element_type*)((uint8_t*)mLayout->data + TypeDetails<element_type>::bytecount * offset);
+    }
+ 
+    const element_type& operator[](int64_t offset) const {
+       return *(element_type*)((uint8_t*)mLayout->data + TypeDetails<element_type>::bytecount * offset);
+    }
+
+    size_t size() const {
+        return !mLayout ? 0 : sizeof(*mLayout) + TypeDetails<element_type>::bytecount * mLayout->count;
+    }
+
+    void append(const element_type& e) {
+        getType()->append((instance_ptr)&mLayout, (instance_ptr)&e);
+    }
+
+    template<class buf_t>
+    void serialize(instance_ptr self, buf_t& buffer) {
+        getType()->serialize<buf_t>((instance_ptr)&mLayout, buffer);
+    }
+
+    template<class buf_t>
+    void deserialize(instance_ptr self, buf_t& buffer) {
+        getType()->serialize<buf_t>((instance_ptr)&mLayout, buffer);
+    }
+
+    ListOf() {
+        mLayout = nullptr;
+    }
+
+    ~ListOf() {
+        getType()->destroy((instance_ptr)&mLayout);
+    }
+
+    ListOf(const ListOf& other)
+    {
+	    getType()->copy_constructor(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&other.mLayout
+               );
+    }
+
+    ListOf& operator=(const ListOf& other)
+    {
+	    getType()->assign(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&other.mLayout
+               );
+        return *this;
+    }
+
+private:
+    ListOfType::layout* mLayout;
+};
+
+template<class element_type>
+class TupleOf {
+public:
+    static TupleOfType* getType() {
+        static TupleOfType* t = TupleOfType::Make(TypeDetails<element_type>::getType());
+
+        return t;
+    }
+
+    //static TupleOf<element_type> fromPython(PyObject* p) {
+        //pyInstance::copyConstructFromPythonInstance(Type* eltType, instance_ptr tgt, PyObject* pyRepresentation, bool isExplicit);
+    //}
+
+    element_type& operator[](int64_t offset) {
+       return *(element_type*)((uint8_t*)mLayout->data + TypeDetails<element_type>::bytecount * offset);
+    }
+
+    const element_type& operator[](int64_t offset) const {
+       return *(element_type*)((uint8_t*)mLayout->data + TypeDetails<element_type>::bytecount * offset);
+    }
+
+    size_t size() const {
+        return !mLayout ? 0 : sizeof(*mLayout) + TypeDetails<element_type>::bytecount * mLayout->count;
+    }
+
+    template<class buf_t>
+    void serialize(instance_ptr self, buf_t& buffer) {
+        TupleOf::serialize<buf_t>((instance_ptr)&mLayout, buffer);
+    }
+
+    template<class buf_t>
+    void deserialize(instance_ptr self, buf_t& buffer) {
+        TupleOf::serialize<buf_t>((instance_ptr)&mLayout, buffer);
+    }
+
+    TupleOf() {
+        mLayout = nullptr;
+    }
+
+    ~TupleOf() {
+        getType()->destroy((instance_ptr)&mLayout);
+    }
+
+    TupleOf(const TupleOf& other)
+    {
+	    getType()->copy_constructor(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&other.mLayout
+               );
+    }
+
+    TupleOf& operator=(const TupleOf& other)
+    {
+	    getType()->assign(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&other.mLayout
+               );
+        return *this;
+    }
+
+private:
+    TupleOfType::layout* mLayout;
+};
+
+// some generated NamedTuples, from
+//gen_named_tuple_type("NamedTupleBoolAndInt", X="int64_t", Y="float")
+class NamedTupleBoolAndInt {
+private:
+	static const int size1 = sizeof(int64_t);
+	static const int size2 = sizeof(float);
+	uint8_t data[size1 + size2];
+public:
+	int64_t& X() { return *(int64_t*)(data); }
+	float& Y() { return *(float*)(data + size1); }
+};
+
+//gen_named_tuple_type("NamedTupleBoolIntStr", X="int64_t", Y="float", Z="str")
+class NamedTupleBoolIntStr {
+private:
+	static const int size1 = sizeof(int64_t);
+	static const int size2 = sizeof(float);
+	static const int size3 = sizeof(str);
+	uint8_t data[size1 + size2 + size3];
+public:
+	int64_t& X() { return *(int64_t*)(data); }
+	float& Y() { return *(float*)(data + size1); }
+	str& Z() { return *(str*)(data + size1 + size2); }
+};
+
+//gen_named_tuple_type("NamedTupleListAndTupleOfStr", items="ListOf<str>", elements="TupleOf<str>")
+class NamedTupleListAndTupleOfStr {
+private:
+	static const int size1 = sizeof(ListOf<str>);
+	static const int size2 = sizeof(TupleOf<str>);
+	uint8_t data[size1 + size2];
+public:
+	ListOf<str>& items() { return *(ListOf<str>*)(data); }
+	TupleOf<str>& elements() { return *(TupleOf<str>*)(data + size1); }
+};
+
+
+/*
+
+//generate code for NamedTuple, Alternative, Class, etc.
+class NamedTuple {
+public:
+   
+};
+
+
+So for NamedTuple(X=bool,Y=int).
+
+class NamedTupleBoolAndInt {
+Public:
+    bool& X() { return *(bool*)data;
+    int64_t& Y() { return *(int64_t*)(data+1);
+Private:
+    Uint8_t data[9];
+}
+
+
+# explicitly list all the named tuples, Alternatives, Classes you want
+# to define.
+typed_python_codegen(
+    Blah=NamedTuple(X=int, Y=float),
+    ServerToClientMessage=messages.ServerToClient,
+    #if something is missing, this won’t compile
+    ...
+);
+
+
+
+What would be ideal:
+
+In python, define something like
+
+ClientToServer = Alternative(
+    "ClientToServer",
+    TransactionData={
+        "writes": ConstDict(ObjectFieldId, OneOf(None, bytes)),
+        "set_adds": ConstDict(IndexId, TupleOf(ObjectId)),
+        "set_removes": ConstDict(IndexId, TupleOf(ObjectId)),
+        "key_versions": TupleOf(ObjectFieldId),
+        "index_versions": TupleOf(IndexId),
+        "transaction_guid": int
+    },
+    CompleteTransaction={
+        "as_of_version": int,
+        "transaction_guid": int
+    },
+    Heartbeat={},
+    LoadLazyObject={ 'schema': str, 'typename': str, 'identity': ObjectId },
+    Subscribe={
+        'schema': str,
+        'typename': OneOf(None, str),
+        'fieldname_and_value': OneOf(None, Tuple(str, bytes)),
+        'isLazy': bool  # load values when we first request them, instead of blocking on all the data.
+    },
+    Flush={'guid': int},
+    Authenticate={'token': str}
+)
+
+
+Generate code like
+
+contents = typed_python_codegen(
+   ClientToServer=ClientToServer,
+   ObjectFieldId=ObjectFieldId,
+   ObjectId=ObjectId,
+   TupleStrAndBytes=Tuple(str,bytes),
+   ) 
+With open(“messages.hpp”, “w”) as f:
+    f.write(contents)
+
+In c++ somewhere
+
+#include “messages.hpp”
+
+
+
+ClientToServer processAMessage(ClientToServer inMessage) {
+   / ******
+   Want to be able to:
+Match on kind of client to server message
+Produce new ones
+Iterate over the dictionary and tuple of internals
+etc.
+}
+
+
+void split(ListOf<String>* out, const String* s, const String* sep) {
+
+}
+ 
+   
+   
+
+*/

--- a/typed_python/PyTupleOrListOfInstance.cpp
+++ b/typed_python/PyTupleOrListOfInstance.cpp
@@ -1,15 +1,15 @@
 #include "PyTupleOrListOfInstance.hpp"
 
-TupleOrListOf* PyTupleOrListOfInstance::type() {
-    return (TupleOrListOf*)extractTypeFrom(((PyObject*)this)->ob_type);
+TupleOrListOfType* PyTupleOrListOfInstance::type() {
+    return (TupleOrListOfType*)extractTypeFrom(((PyObject*)this)->ob_type);
 }
 
-TupleOf* PyTupleOfInstance::type() {
-    return (TupleOf*)extractTypeFrom(((PyObject*)this)->ob_type);
+TupleOfType* PyTupleOfInstance::type() {
+    return (TupleOfType*)extractTypeFrom(((PyObject*)this)->ob_type);
 }
 
-ListOf* PyListOfInstance::type() {
-    return (ListOf*)extractTypeFrom(((PyObject*)this)->ob_type);
+ListOfType* PyListOfInstance::type() {
+    return (ListOfType*)extractTypeFrom(((PyObject*)this)->ob_type);
 }
 
 bool PyTupleOrListOfInstance::pyValCouldBeOfTypeConcrete(modeled_type* type, PyObject* pyRepresentation) {
@@ -134,7 +134,7 @@ PyObject* PyListOfInstance::listSetSizeUnsafe(PyObject* o, PyObject* args) {
 
 
 template<class dest_t, class source_t>
-void constructTupleOrListInst(TupleOrListOf* tupT, instance_ptr tgt, size_t count, uint8_t* source_data) {
+void constructTupleOrListInst(TupleOrListOfType* tupT, instance_ptr tgt, size_t count, uint8_t* source_data) {
     tupT->constructor(tgt, count,
         [&](uint8_t* eltPtr, int64_t k) {
             ((dest_t*)eltPtr)[0] = ((source_t*)source_data)[k];
@@ -143,7 +143,7 @@ void constructTupleOrListInst(TupleOrListOf* tupT, instance_ptr tgt, size_t coun
 }
 
 template<class dest_t>
-bool constructTupleOrListInstFromNumpy(TupleOrListOf* tupT, instance_ptr tgt, size_t size, uint8_t* data, int numpyType) {
+bool constructTupleOrListInstFromNumpy(TupleOrListOfType* tupT, instance_ptr tgt, size_t size, uint8_t* data, int numpyType) {
     if (numpyType == NPY_FLOAT64) {
         constructTupleOrListInst<dest_t, double>(tupT, tgt, size, data);
     } else if (numpyType == NPY_FLOAT32) {
@@ -172,7 +172,7 @@ bool constructTupleOrListInstFromNumpy(TupleOrListOf* tupT, instance_ptr tgt, si
 
     return true;
 }
-void PyTupleOrListOfInstance::copyConstructFromPythonInstanceConcrete(TupleOrListOf* tupT, instance_ptr tgt, PyObject* pyRepresentation, bool isExplicit) {
+void PyTupleOrListOfInstance::copyConstructFromPythonInstanceConcrete(TupleOrListOfType* tupT, instance_ptr tgt, PyObject* pyRepresentation, bool isExplicit) {
     if (PyArray_Check(pyRepresentation)) {
         if (!PyArray_ISBEHAVED_RO(pyRepresentation)) {
             throw std::logic_error("Can't convert a numpy array that's not contiguous and in machine-native byte order.");
@@ -688,7 +688,7 @@ PyMethodDef* PyListOfInstance::typeMethodsConcrete() {
     };
 }
 
-void PyListOfInstance::constructFromPythonArgumentsConcrete(ListOf* t, uint8_t* data, PyObject* args, PyObject* kwargs) {
+void PyListOfInstance::constructFromPythonArgumentsConcrete(ListOfType* t, uint8_t* data, PyObject* args, PyObject* kwargs) {
     if (PyTuple_Size(args) == 1 && !kwargs) {
         PyObject* arg = PyTuple_GetItem(args, 0);
         Type* argType = extractTypeFrom(arg->ob_type);
@@ -697,7 +697,7 @@ void PyListOfInstance::constructFromPythonArgumentsConcrete(ListOf* t, uint8_t* 
             //following python semantics, this needs to produce a new object
             //that's a copy of the original list. We can't just incref it and return
             //the original object because it has state.
-            ListOf* listT = (ListOf*)t;
+            ListOfType* listT = (ListOfType*)t;
             listT->copyListObject(data, ((PyInstance*)arg)->dataPtr());
             return;
         }
@@ -706,7 +706,7 @@ void PyListOfInstance::constructFromPythonArgumentsConcrete(ListOf* t, uint8_t* 
     PyInstance::constructFromPythonArgumentsConcrete(t, data, args, kwargs);
 }
 
-void PyTupleOrListOfInstance::mirrorTypeInformationIntoPyTypeConcrete(TupleOrListOf* inType, PyTypeObject* pyType) {
+void PyTupleOrListOfInstance::mirrorTypeInformationIntoPyTypeConcrete(TupleOrListOfType* inType, PyTypeObject* pyType) {
     //expose 'ElementType' as a member of the type object
     PyDict_SetItemString(
         pyType->tp_dict,

--- a/typed_python/PyTupleOrListOfInstance.hpp
+++ b/typed_python/PyTupleOrListOfInstance.hpp
@@ -4,9 +4,9 @@
 
 class PyTupleOrListOfInstance : public PyInstance {
 public:
-    typedef TupleOrListOf modeled_type;
+    typedef TupleOrListOfType modeled_type;
 
-    TupleOrListOf* type();
+    TupleOrListOfType* type();
 
     PyObject* sq_item_concrete(Py_ssize_t ix);
 
@@ -14,7 +14,7 @@ public:
 
     PyObject* mp_subscript_concrete(PyObject* item);
 
-    static void copyConstructFromPythonInstanceConcrete(TupleOrListOf* tupT, instance_ptr tgt, PyObject* pyRepresentation, bool isExplicit);
+    static void copyConstructFromPythonInstanceConcrete(TupleOrListOfType* tupT, instance_ptr tgt, PyObject* pyRepresentation, bool isExplicit);
 
     PyObject* pyOperatorConcrete(PyObject* rhs, const char* op, const char* opErr);
 
@@ -26,14 +26,14 @@ public:
 
     static bool pyValCouldBeOfTypeConcrete(modeled_type* type, PyObject* pyRepresentation);
 
-    static void mirrorTypeInformationIntoPyTypeConcrete(TupleOrListOf* inType, PyTypeObject* pyType);
+    static void mirrorTypeInformationIntoPyTypeConcrete(TupleOrListOfType* inType, PyTypeObject* pyType);
 };
 
 class PyListOfInstance : public PyTupleOrListOfInstance {
 public:
-    typedef ListOf modeled_type;
+    typedef ListOfType modeled_type;
 
-    ListOf* type();
+    ListOfType* type();
 
     static PyObject* listAppend(PyObject* o, PyObject* args);
 
@@ -55,9 +55,9 @@ public:
 
     static PyMethodDef* typeMethodsConcrete();
 
-    static void constructFromPythonArgumentsConcrete(ListOf* t, uint8_t* data, PyObject* args, PyObject* kwargs);
+    static void constructFromPythonArgumentsConcrete(ListOfType* t, uint8_t* data, PyObject* args, PyObject* kwargs);
 
-    static bool compare_to_python_concrete(ListOf* listT, instance_ptr self, PyObject* other, bool exact, int pyComparisonOp) {
+    static bool compare_to_python_concrete(ListOfType* listT, instance_ptr self, PyObject* other, bool exact, int pyComparisonOp) {
         auto convert = [&](char cmpValue) { return cmpResultToBoolForPyOrdering(pyComparisonOp, cmpValue); };
 
         if (!PyList_Check(other)) {
@@ -83,13 +83,13 @@ public:
 
 class PyTupleOfInstance : public PyTupleOrListOfInstance {
 public:
-    typedef TupleOf modeled_type;
+    typedef TupleOfType modeled_type;
 
-    TupleOf* type();
+    TupleOfType* type();
 
     static PyMethodDef* typeMethodsConcrete();
 
-    static bool compare_to_python_concrete(TupleOf* tupT, instance_ptr self, PyObject* other, bool exact, int pyComparisonOp) {
+    static bool compare_to_python_concrete(TupleOfType* tupT, instance_ptr self, PyObject* other, bool exact, int pyComparisonOp) {
         auto convert = [&](char cmpValue) { return cmpResultToBoolForPyOrdering(pyComparisonOp, cmpValue); };
 
         if (!PyTuple_Check(other)) {

--- a/typed_python/PythonSerializationContext.cpp
+++ b/typed_python/PythonSerializationContext.cpp
@@ -483,12 +483,12 @@ void PythonSerializationContext::serializeNativeType(Type* nativeType, Serializa
     }
 
     if (nativeType->getTypeCategory() == Type::TypeCategory::catTupleOf) {
-        serializeNativeType(((TupleOf*)nativeType)->getEltType(), b);
+        serializeNativeType(((TupleOfType*)nativeType)->getEltType(), b);
         return;
     }
 
     if (nativeType->getTypeCategory() == Type::TypeCategory::catListOf) {
-        serializeNativeType(((ListOf*)nativeType)->getEltType(), b);
+        serializeNativeType(((ListOfType*)nativeType)->getEltType(), b);
         return;
     }
 
@@ -662,13 +662,13 @@ Type* PythonSerializationContext::deserializeNativeTypeUncached(DeserializationB
     }
 
     if (category == Type::TypeCategory::catTupleOf) {
-        return ::TupleOf::Make(
+        return ::TupleOfType::Make(
             deserializeNativeType(b)
             );
     }
 
     if (category == Type::TypeCategory::catListOf) {
-        return ::ListOf::Make(
+        return ::ListOfType::Make(
             deserializeNativeType(b)
             );
     }

--- a/typed_python/StringType.hpp
+++ b/typed_python/StringType.hpp
@@ -44,6 +44,10 @@ public:
     static int64_t find(layout* l, layout* sub, int64_t start, int64_t end);
     static int64_t find_2(layout* l, layout* sub);
     static int64_t find_3(layout* l, layout* sub, int64_t start);
+    static void split(ListOfType::layout *outList, layout* l, layout* sep, int64_t max);
+    static void split_2(ListOfType::layout *outList, layout* l);
+    static void split_3(ListOfType::layout *outList, layout* l, layout* sep);
+    static void split_3max(ListOfType::layout *outList, layout* l, int64_t max);
 
     static bool isalpha(layout *l);
     static bool isalnum(layout *l);
@@ -59,6 +63,7 @@ public:
     //return an increffed string containing the one codepoint at 'offset'. this function
     //will correctly map negative indices, but performs no other boundschecking.
     static layout* getitem(layout* lhs, int64_t offset);
+    static layout* getsubstr(layout* lhs, int64_t start, int64_t stop);
 
     //return an increffed string containing the data from the utf-encoded string
     static layout* createFromUtf8(const char* utfEncodedString, int64_t len);

--- a/typed_python/TupleOrListOfType.cpp
+++ b/typed_python/TupleOrListOfType.cpp
@@ -1,16 +1,16 @@
 #include "AllTypes.hpp"
 
-bool TupleOrListOf::isBinaryCompatibleWithConcrete(Type* other) {
+bool TupleOrListOfType::isBinaryCompatibleWithConcrete(Type* other) {
     if (other->getTypeCategory() != m_typeCategory) {
         return false;
     }
 
-    TupleOf* otherO = (TupleOf*)other;
+    TupleOfType* otherO = (TupleOfType*)other;
 
     return m_element_type->isBinaryCompatibleWith(otherO->m_element_type);
 }
 
-void TupleOrListOf::repr(instance_ptr self, ReprAccumulator& stream) {
+void TupleOrListOfType::repr(instance_ptr self, ReprAccumulator& stream) {
     PushReprState isNew(stream, self);
 
     if (!isNew) {
@@ -38,7 +38,7 @@ void TupleOrListOf::repr(instance_ptr self, ReprAccumulator& stream) {
     stream << (m_is_tuple ? ")" : "]");
 }
 
-int32_t TupleOrListOf::hash32(instance_ptr left) {
+int32_t TupleOrListOfType::hash32(instance_ptr left) {
     if (!(*(layout**)left)) {
         return 0x123;
     }
@@ -62,7 +62,7 @@ int32_t TupleOrListOf::hash32(instance_ptr left) {
     return (*(layout**)left)->hash_cache;
 }
 
-bool TupleOrListOf::cmp(instance_ptr left, instance_ptr right, int pyComparisonOp) {
+bool TupleOrListOfType::cmp(instance_ptr left, instance_ptr right, int pyComparisonOp) {
     if (!(*(layout**)left) && (*(layout**)right)) {
         return cmpResultToBoolForPyOrdering(pyComparisonOp, -1);
     }
@@ -124,38 +124,38 @@ bool TupleOrListOf::cmp(instance_ptr left, instance_ptr right, int pyComparisonO
 }
 
 // static
-TupleOf* TupleOf::Make(Type* elt) {
+TupleOfType* TupleOfType::Make(Type* elt) {
     static std::mutex guard;
 
     std::lock_guard<std::mutex> lock(guard);
 
-    static std::map<Type*, TupleOf*> m;
+    static std::map<Type*, TupleOfType*> m;
 
     auto it = m.find(elt);
     if (it == m.end()) {
-        it = m.insert(std::make_pair(elt, new TupleOf(elt))).first;
+        it = m.insert(std::make_pair(elt, new TupleOfType(elt))).first;
     }
 
     return it->second;
 }
 
 // static
-ListOf* ListOf::Make(Type* elt) {
+ListOfType* ListOfType::Make(Type* elt) {
     static std::mutex guard;
 
     std::lock_guard<std::mutex> lock(guard);
 
-    static std::map<Type*, ListOf*> m;
+    static std::map<Type*, ListOfType*> m;
 
     auto it = m.find(elt);
     if (it == m.end()) {
-        it = m.insert(std::make_pair(elt, new ListOf(elt))).first;
+        it = m.insert(std::make_pair(elt, new ListOfType(elt))).first;
     }
 
     return it->second;
 }
 
-int64_t TupleOrListOf::count(instance_ptr self) const {
+int64_t TupleOrListOfType::count(instance_ptr self) const {
     if (!(*(layout**)self)) {
         return 0;
     }
@@ -163,7 +163,7 @@ int64_t TupleOrListOf::count(instance_ptr self) const {
     return (*(layout**)self)->count;
 }
 
-int64_t TupleOrListOf::refcount(instance_ptr self) const {
+int64_t TupleOrListOfType::refcount(instance_ptr self) const {
     if (!(*(layout**)self)) {
         return 0;
     }
@@ -171,11 +171,11 @@ int64_t TupleOrListOf::refcount(instance_ptr self) const {
     return (*(layout**)self)->refcount;
 }
 
-void TupleOrListOf::constructor(instance_ptr self) {
+void TupleOrListOfType::constructor(instance_ptr self) {
     constructor(self, 0, [](instance_ptr i, int64_t k) {});
 }
 
-void TupleOrListOf::destroy(instance_ptr selfPtr) {
+void TupleOrListOfType::destroy(instance_ptr selfPtr) {
     layout_ptr& self = *(layout_ptr*)selfPtr;
 
     if (!self) {
@@ -189,14 +189,17 @@ void TupleOrListOf::destroy(instance_ptr selfPtr) {
     }
 }
 
-void TupleOrListOf::copy_constructor(instance_ptr self, instance_ptr other) {
+void TupleOrListOfType::copy_constructor(instance_ptr self, instance_ptr other) {
     (*(layout**)self) = (*(layout**)other);
     if (*(layout**)self) {
         (*(layout**)self)->refcount++;
     }
 }
 
-void TupleOrListOf::assign(instance_ptr self, instance_ptr other) {
+void TupleOrListOfType::assign(instance_ptr self, instance_ptr other) {
+    if (self == other)
+        return;
+
     layout* old = (*(layout**)self);
 
     (*(layout**)self) = (*(layout**)other);
@@ -208,7 +211,7 @@ void TupleOrListOf::assign(instance_ptr self, instance_ptr other) {
     destroy((instance_ptr)&old);
 }
 
-void TupleOrListOf::reserve(instance_ptr self, size_t target) {
+void TupleOrListOfType::reserve(instance_ptr self, size_t target) {
     layout_ptr& self_layout = *(layout_ptr*)self;
 
     if (target < self_layout->count) {
@@ -221,19 +224,19 @@ void TupleOrListOf::reserve(instance_ptr self, size_t target) {
 
 
 //static
-void ListOf::copyListObject(instance_ptr target, instance_ptr src) {
+void ListOfType::copyListObject(instance_ptr target, instance_ptr src) {
     constructor(target, count(src), [&](instance_ptr tgt, long k) {
         return m_element_type->copy_constructor(tgt, eltPtr(src,k));
     });
 }
 
-void ListOf::setSizeUnsafe(instance_ptr self, size_t count) {
+void ListOfType::setSizeUnsafe(instance_ptr self, size_t count) {
     layout_ptr& self_layout = *(layout_ptr*)self;
 
     self_layout->count = count;
 }
 
-void ListOf::append(instance_ptr self, instance_ptr other) {
+void ListOfType::append(instance_ptr self, instance_ptr other) {
     layout_ptr& self_layout = *(layout_ptr*)self;
 
     if (!self_layout) {
@@ -257,12 +260,12 @@ void ListOf::append(instance_ptr self, instance_ptr other) {
     }
 }
 
-size_t ListOf::reserved(instance_ptr self) {
+size_t ListOfType::reserved(instance_ptr self) {
     layout_ptr& self_layout = *(layout_ptr*)self;
 
     return self_layout->reserved;
 }
-void ListOf::remove(instance_ptr self, size_t index) {
+void ListOfType::remove(instance_ptr self, size_t index) {
     layout_ptr& self_layout = *(layout_ptr*)self;
 
     getEltType()->destroy(eltPtr(self, index));
@@ -270,7 +273,7 @@ void ListOf::remove(instance_ptr self, size_t index) {
     self_layout->count--;
 }
 
-void ListOf::resize(instance_ptr self, size_t count) {
+void ListOfType::resize(instance_ptr self, size_t count) {
     layout_ptr& self_layout = *(layout_ptr*)self;
 
     if (count > self_layout->reserved) {
@@ -287,7 +290,7 @@ void ListOf::resize(instance_ptr self, size_t count) {
     }
 }
 
-void ListOf::resize(instance_ptr self, size_t count, instance_ptr value) {
+void ListOfType::resize(instance_ptr self, size_t count, instance_ptr value) {
     layout_ptr& self_layout = *(layout_ptr*)self;
 
     if (count > self_layout->reserved) {

--- a/typed_python/TupleOrListOfType.hpp
+++ b/typed_python/TupleOrListOfType.hpp
@@ -2,8 +2,8 @@
 
 #include "Type.hpp"
 
-class TupleOrListOf : public Type {
-protected:
+class TupleOrListOfType : public Type {
+public:
     class layout {
     public:
         std::atomic<int64_t> refcount;
@@ -16,7 +16,7 @@ protected:
     typedef layout* layout_ptr;
 
 public:
-    TupleOrListOf(Type* type, bool isTuple) :
+    TupleOrListOfType(Type* type, bool isTuple) :
             Type(isTuple ? TypeCategory::catTupleOf : TypeCategory::catListOf),
             m_element_type(type),
             m_is_tuple(isTuple)
@@ -40,7 +40,7 @@ public:
     }
 
     void _forwardTypesMayHaveChanged() {
-        m_name = (m_is_tuple ? "TupleOf(" : "ListOf(") + m_element_type->name() + ")";
+        m_name = (m_is_tuple ? "TupleOfType(" : "ListOfType(") + m_element_type->name() + ")";
     }
 
     template<class buf_t>
@@ -183,13 +183,13 @@ protected:
     bool m_is_tuple;
 };
 
-class ListOf : public TupleOrListOf {
+class ListOfType : public TupleOrListOfType {
 public:
-    ListOf(Type* type) : TupleOrListOf(type, false)
+    ListOfType(Type* type) : TupleOrListOfType(type, false)
     {
     }
 
-    static ListOf* Make(Type* elt);
+    static ListOfType* Make(Type* elt);
 
     void setSizeUnsafe(instance_ptr self, size_t count);
 
@@ -206,12 +206,12 @@ public:
     void copyListObject(instance_ptr target, instance_ptr src);
 };
 
-class TupleOf : public TupleOrListOf {
+class TupleOfType : public TupleOrListOfType {
 public:
-    TupleOf(Type* type) : TupleOrListOf(type, true)
+    TupleOfType(Type* type) : TupleOrListOfType(type, true)
     {
     }
 
-    static TupleOf* Make(Type* elt);
+    static TupleOfType* Make(Type* elt);
 };
 

--- a/typed_python/Type.hpp
+++ b/typed_python/Type.hpp
@@ -37,9 +37,9 @@ class String;
 class Bytes;
 class OneOf;
 class Value;
-class TupleOf;
+class TupleOfType;
 class PointerTo;
-class ListOf;
+class ListOfType;
 class NamedTuple;
 class Tuple;
 class Dict;
@@ -192,11 +192,11 @@ public:
             case catOneOf:
                 return f(*(OneOf*)this);
             case catTupleOf:
-                return f(*(TupleOf*)this);
+                return f(*(TupleOfType*)this);
             case catPointerTo:
                 return f(*(PointerTo*)this);
             case catListOf:
-                return f(*(ListOf*)this);
+                return f(*(ListOfType*)this);
             case catNamedTuple:
                 return f(*(NamedTuple*)this);
             case catTuple:

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -42,6 +42,22 @@ extern "C" {
         return String::find_3(l, sub, start);
     }
 
+    void nativepython_runtime_string_split(ListOfType::layout* outList, String::layout* l, String::layout* sep, int64_t max) {
+        String::split(outList, l, sep, max);
+    }
+
+    void nativepython_runtime_string_split_2(ListOfType::layout* outList, String::layout* l) {
+        String::split_2(outList, l);
+    }
+
+    void nativepython_runtime_string_split_3(ListOfType::layout* outList, String::layout* l, String::layout* sep) {
+        String::split_3(outList, l, sep);
+    }
+
+    void nativepython_runtime_string_split_3max(ListOfType::layout* outList, String::layout* l, int64_t max) {
+        String::split_3max(outList, l, max);
+    }
+
     bool nativepython_runtime_string_isalpha(String::layout* l) {
         return String::isalpha(l);
     }
@@ -196,6 +212,5 @@ extern "C" {
 
         throw std::runtime_error("Couldn't convert to an int64.");
     }
-
 
 }

--- a/typed_python/_types.cpp
+++ b/typed_python/_types.cpp
@@ -25,16 +25,16 @@ PyObject *MakeTupleOrListOfType(PyObject* nullValue, PyObject* args, bool isTupl
 
     if (types.size() != 1) {
         if (isTuple) {
-            PyErr_SetString(PyExc_TypeError, "TupleOf takes 1 positional argument.");
+            PyErr_SetString(PyExc_TypeError, "TupleOfType takes 1 positional argument.");
         } else {
-            PyErr_SetString(PyExc_TypeError, "ListOf takes 1 positional argument.");
+            PyErr_SetString(PyExc_TypeError, "ListOfType takes 1 positional argument.");
         }
         return NULL;
     }
 
     return incref(
         (PyObject*)PyInstance::typeObj(
-            isTuple ? (TupleOrListOf*)TupleOf::Make(types[0]) : (TupleOrListOf*)ListOf::Make(types[0])
+            isTuple ? (TupleOrListOfType*)TupleOfType::Make(types[0]) : (TupleOrListOfType*)ListOfType::Make(types[0])
             )
         );
 }
@@ -644,13 +644,13 @@ PyObject *refcount(PyObject* nullValue, PyObject* args) {
 
     if (actualType->getTypeCategory() == Type::TypeCategory::catTupleOf) {
         return PyLong_FromLong(
-            ((::TupleOf*)actualType)->refcount(((PyInstance*)a1)->dataPtr())
+            ((::TupleOfType*)actualType)->refcount(((PyInstance*)a1)->dataPtr())
             );
     }
 
     if (actualType->getTypeCategory() == Type::TypeCategory::catListOf) {
         return PyLong_FromLong(
-            ((::ListOf*)actualType)->refcount(((PyInstance*)a1)->dataPtr())
+            ((::ListOfType*)actualType)->refcount(((PyInstance*)a1)->dataPtr())
             );
     }
 

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -359,7 +359,7 @@ class NativeTypesTests(unittest.TestCase):
 
     def test_list_of(self):
         L = ListOf(int)
-        self.assertEqual(L.__qualname__, "ListOf(Int64)")
+        self.assertEqual(L.__qualname__, "ListOfType(Int64)")
 
         l1 = L([1, 2, 3, 4])
 


### PR DESCRIPTION
## Motivation and Context
* Provide some c++ type wrappers corresponding to Types, that can be directly used (not via Python).

## Approach
* Provide some c++ type wrappers corresponding to Types:
    str for String
    ListOf<> for ListOfType()
    TupleOf<> for TupleOfType()
* Rudimentary generation of NamedTuple wrappers
    examples: NamedTupleBoolAndInt, NamedTupleBoolIntStr, NamedTupleListAndTupleOfStr
* seeking code review
* Also, finished implementing String.split(), using existing methods to build list.

## How Has This Been Tested?
* String.split() has test cases
* new wrapper types not tested (verify approach first)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.