### PR TITLE
Warn about unused variables and Fix those Warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,10 @@ TP_LIB_PATH ?= build/lib.linux-x86_64-3.6/typed_python
 ODB_BUILD_PATH ?= build/temp.linux-x86_64-3.6/object_database
 ODB_LIB_PATH ?= build/lib.linux-x86_64-3.6/object_database
 
-CPP_FLAGS = -std=c++14 -O2 -Wall -pthread -DNDEBUG -g -fwrapv               \
-            -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIC              \
-            -Wformat -Werror=format-security -Wdate-time                    \
-            -Wno-sign-compare -Wno-narrowing                                \
-            -Wno-unused-variable -Wno-int-in-bool-context                   \
+CPP_FLAGS = -std=c++14  -O2  -Wall  -pthread  -DNDEBUG  -g  -fwrapv         \
+            -fstack-protector-strong  -D_FORTIFY_SOURCE=2  -fPIC            \
+            -Wformat  -Werror=format-security  -Wdate-time                  \
+            -Wno-sign-compare  -Wno-narrowing  -Wno-int-in-bool-context     \
             -I$(VIRTUAL_ENV)/include/python3.6m                             \
             -I$(VIRTUAL_ENV)/lib/python3.6/site-packages/numpy/core/include \
             -I/usr/include/python3.6m                                       \

--- a/object_database/VersionedObjectsOfType.hpp
+++ b/object_database/VersionedObjectsOfType.hpp
@@ -412,8 +412,6 @@ public:
             curNAP = m_next_and_prior.lookupKey(ObjectAndVersion(objectId, curVersion));
         }
 
-        transaction_id priorVersion = curNAP->priorId;
-
         NextAndPrior* curInteriorNAP = m_next_and_prior.insertKey(objIdAndVersion);
 
         //this can reallocate the table, so we need to reload both

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,7 @@ extra_compile_args = [
     '-Werror=format-security',
     '-std=c++14',
     '-Wno-sign-compare',
-    '-Wno-narrowing',
-    '-Wno-unused-variable'
+    '-Wno-narrowing'
 ]
 
 ext_modules = [

--- a/typed_python/PyClassInstance.cpp
+++ b/typed_python/PyClassInstance.cpp
@@ -184,10 +184,6 @@ std::pair<bool, PyObject*> PyClassInstance::callMemberFunction(const char* name,
         PyTuple_SetItem(targetArgTuple, 2, incref(arg1)); //steals a reference
     }
 
-    // FIXME: why am I not getting a warning about unused var 'threw'
-    bool threw = false;
-    bool ran = false;
-
     auto res = PyFunctionInstance::tryToCallAnyOverload(method, nullptr, targetArgTuple, nullptr);
     if (res.first) {
         return res;

--- a/typed_python/PyPointerToInstance.cpp
+++ b/typed_python/PyPointerToInstance.cpp
@@ -114,7 +114,6 @@ PyObject* PyPointerToInstance::pointerGet(PyObject* o, PyObject* args) {
 //static
 PyObject* PyPointerToInstance::pointerCast(PyObject* o, PyObject* args) {
     PyInstance* self_w = (PyInstance*)o;
-    PointerTo* pointerT = (PointerTo*)extractTypeFrom(o->ob_type);
 
     if (PyTuple_Size(args) != 1) {
         PyErr_SetString(PyExc_TypeError, "PointerTo.cast takes one argument");

--- a/typed_python/PyTupleOrListOfInstance.cpp
+++ b/typed_python/PyTupleOrListOfInstance.cpp
@@ -474,7 +474,6 @@ PyObject* PyListOfInstance::listAppend(PyObject* o, PyObject* args) {
         PyObjectHolder value(PyTuple_GetItem(args, 0));
 
         PyListOfInstance* self_w = (PyListOfInstance*)o;
-        PyInstance* value_w = (PyInstance*)(PyObject*)value;
 
         Type* value_type = extractTypeFrom(value->ob_type);
 

--- a/typed_python/PythonSerializationContext.cpp
+++ b/typed_python/PythonSerializationContext.cpp
@@ -121,8 +121,6 @@ void PythonSerializationContext::serializePyDict(PyObject* o, SerializationBuffe
         PyObject *key, *value;
         Py_ssize_t pos = 0;
 
-        int i = 0;
-
         while (PyDict_Next(o, &pos, &key, &value)) {
             serializePythonObject(key, b);
             serializePythonObject(value, b);

--- a/typed_python/Type.hpp
+++ b/typed_python/Type.hpp
@@ -309,8 +309,6 @@ public:
     Type* guaranteeForwardsResolvedConcrete(resolve_py_callable_to_type& resolver) {
         typedef Type* type_ptr;
 
-        bool didSomething = false;
-
         visitReferencedTypes([&](type_ptr& t) {
             t = t->guaranteeForwardsResolved(resolver);
         });

--- a/typed_python/_types.cpp
+++ b/typed_python/_types.cpp
@@ -1035,8 +1035,6 @@ PyObject *MakeAlternativeType(PyObject* nullValue, PyObject* args, PyObject* kwa
     PyObject *key, *value;
     Py_ssize_t pos = 0;
 
-    int i = 0;
-
     while (kwargs && PyDict_Next(kwargs, &pos, &key, &value)) {
         assert(PyUnicode_Check(key));
 

--- a/typed_python/util.cpp
+++ b/typed_python/util.cpp
@@ -132,7 +132,6 @@ bool unpackTupleToStringAndObjects(PyObject* tuple, std::vector<std::pair<std::s
 
     for (int i = 0; i < PyTuple_Size(tuple); ++i) {
         PyObjectHolder entry(PyTuple_GetItem(tuple, i));
-        Type* targetType = NULL;
 
         if (!PyTuple_Check(entry) || PyTuple_Size(entry) != 2
                 || !PyUnicode_Check(PyTuple_GetItem(entry, 0))


### PR DESCRIPTION
## Motivation and Context
Unused variables represent either left-over dead-code or indicate that we forgot to use an input into the code coming after the variable definition. It's a good idea to get warnings about them and address them.

## Approach
Removed the `-Wno-unused-variable` compiler flag from `setup.py` and `Makefile`, recompiled the code and fixed all unused-variable warnings.

## How Has This Been Tested?
TravisCI is happy

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.