### PR TITLE
Update dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,30 +4,31 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-nose = "*"
-flake8 = "*"
 autopep8 = "*"
 beautifulsoup4 = "*"
+flake8 = "*"
+nose = "*"
 py_w3c = "*"
 
 [packages]
-redis = "*"
+boto3 = "*"
+flask = "*"
+flask-cors = "*"
+flask-login = "*"
+flask-sockets = "*"
+flask-wtf = "*"
 gevent = "*"
+ldap3 = "*"
+llvmlite = "*"
 lz4 = "*"
 numpy = "*"
 psutil = "*"
-flask-sockets = "*"
-flask-cors = "*"
+pytz = "*"
+pyyaml = "*"
+redis = "*"
 requests = "*"
 websockets = "*"
-llvmlite = "*"
 nativepython = {editable = true,path = "."}
-boto3 = "*"
-pyyaml = "*"
-ldap3 = "*"
-flask-login = "*"
-flask-wtf = "*"
-pytz = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -26,18 +26,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0f915edb23c82a5e9f4d6956e7e172191006f57af4747d9a0e52056b708cc35c",
-                "sha256:317adb3640991dc16a65f093a835a9249263100e3e65a9ab4e3f2a9eeb237e8a"
+                "sha256:bb69628f933a8dba22817c85289b3421b23ac643ff3202b13dd2e933c2717109",
+                "sha256:c75c45bae9dbdb2ff3fc3482d421a3901e552574a882dba1cffa064715acfbe7"
             ],
             "index": "pypi",
-            "version": "==1.9.127"
+            "version": "==1.9.130"
         },
         "botocore": {
             "hashes": [
-                "sha256:b62cb7948d3e3c9a7c3708d2c5bc13f4ca7e68c4c53768ce366f3026a75ef394",
-                "sha256:be21b6c2a441c0fd18d472691559680056f37609b64779c966625f59ecb2bbbb"
+                "sha256:128130b12f8ba4bf07a673b119135264060eb98f6a4a7419cbd1f2c6dc926827",
+                "sha256:59376112fdee707927b644dd44a1771861f8fe354a48d596131ced83d7a3c05b"
             ],
-            "version": "==1.12.127"
+            "version": "==1.12.130"
         },
         "certifi": {
             "hashes": [
@@ -183,10 +183,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
-                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
             ],
-            "version": "==2.10"
+            "version": "==2.10.1"
         },
         "jmespath": {
             "hashes": [
@@ -380,11 +380,11 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
-                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
+                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
+                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
             ],
             "index": "pypi",
-            "version": "==2018.9"
+            "version": "==2019.1"
         },
         "pyyaml": {
             "hashes": [
@@ -435,10 +435,10 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:3aef141566afd07201b525c17bfaadd07580a8066f82b57f7c9417f26adbd0a3",
-                "sha256:e41a65e99bd125972d84221022beb1e4b5cfc68fa12c170c39834ce32d1b294c"
+                "sha256:6898e82ecb03772a0d82bd0d0a10c0d6dcc342f77e0701d0ec4a8271be465ece",
+                "sha256:b20eff5e564529711544066d7dc0f7661df41232ae263619dede5059799cdfca"
             ],
-            "version": "==1.9"
+            "version": "==1.9.1"
         },
         "urllib3": {
             "hashes": [
@@ -493,10 +493,10 @@
     "develop": {
         "autopep8": {
             "hashes": [
-                "sha256:33d2b5325b7e1afb4240814fe982eea3a92ebea712869bfd08b3c0393404248c"
+                "sha256:4d8eec30cc81bc5617dbf1218201d770dc35629363547f17577c61683ccfb3ee"
             ],
             "index": "pypi",
-            "version": "==1.4.3"
+            "version": "==1.4.4"
         },
         "beautifulsoup4": {
             "hashes": [
@@ -558,10 +558,10 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:3aef141566afd07201b525c17bfaadd07580a8066f82b57f7c9417f26adbd0a3",
-                "sha256:e41a65e99bd125972d84221022beb1e4b5cfc68fa12c170c39834ce32d1b294c"
+                "sha256:6898e82ecb03772a0d82bd0d0a10c0d6dcc342f77e0701d0ec4a8271be465ece",
+                "sha256:b20eff5e564529711544066d7dc0f7661df41232ae263619dede5059799cdfca"
             ],
-            "version": "==1.9"
+            "version": "==1.9.1"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "95d4a0f0c139d62debf3f7976a7a7a4d8f69009cbedf1dadcc39593787e895f9"
+            "sha256": "d426f8a3b1d13f2a4cb1393e7a970eda2e89bfe588c85b708de8d95d7b7ad4ef"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -73,6 +73,7 @@
                 "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48",
                 "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
             ],
+            "index": "pypi",
             "version": "==1.0.2"
         },
         "flask-cors": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-numpy
-flask
-boto3
 beautifulsoup4
+boto3
 flask
-flask_cors
+flask-cors
 flask-login
 flask-sockets
 flask-wtf
@@ -15,8 +13,8 @@ nose
 numpy
 psutil
 pytz
+py_w3c
 pyyaml
 redis
 requests
 websockets
-py_w3c


### PR DESCRIPTION
# Purpose
We got an alert from Github that our dependency on jinja2==2.10
introduced a vulnerability. 

# Approach
I ran `pipenv lock --dev` to update our  to the latest versions. 

Also, did some dependency clean-up:
- removed duplicates from requirements.txt
- flask_cors -> flask-cors
- added missing dependency "flask" to Pipfile
- sorted dependencies alphabetically in requirements.txt and 

Re-ran pipenv lock --dev to update Pipfile.lock after these changes

Checked with `pipenv graph` that we no longer have duplicate direct  (we had `flask` and `numpy` because they appeared twice in `requirements.txt`)


