### PR TITLE
Asynchronous Dropdown Cell

### DIFF
--- a/object_database/frontends/object_database_webtest.py
+++ b/object_database/frontends/object_database_webtest.py
@@ -24,7 +24,8 @@ from object_database.service_manager.ServiceManager_test import (
     GraphDisplayService,
     TextEditorService,
     HappyService,
-    UninitializableService
+    UninitializableService,
+    DropdownTestService
 )
 from object_database.web.ActiveWebService import (
     active_webservice_schema,
@@ -95,6 +96,10 @@ def main(argv=None):
             with database.transaction():
                 service = ServiceManager.createOrUpdateService(
                     TextEditorService, "TextEditorService", target_count=1
+                )
+            with database.transaction():
+                service = ServiceManager.createOrUpdateService(
+                    DropdownTestService, "DropdownTestService", target_count=1
                 )
             while True:
                 time.sleep(.1)

--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -301,7 +301,7 @@ class DropdownTestService(ServiceBase):
     @staticmethod
     def serviceDisplay(serviceObject, instance=None, objType=None, queryArgs=None):
         return Card(
-            AsyncDropdown(DropdownTestService.delayAndDisplay)
+            AsyncDropdown('Dropdown', DropdownTestService.delayAndDisplay)
         )
 
     @staticmethod

--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -306,7 +306,7 @@ class DropdownTestService(ServiceBase):
 
     @staticmethod
     def delayAndDisplay():
-        time.sleep(3)
+        time.sleep(1)
         return Text('NOW WE HAVE LOADED')
 
 happy = Schema("core.test.happy")

--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -29,7 +29,7 @@ import object_database.service_manager.ServiceInstance as ServiceInstance
 from object_database.web.cells import (
     Button, SubscribedSequence, Subscribed,
     Text, Dropdown, Card, Plot, Code, Slot, CodeEditor, Columns, Tabs, Grid,
-    Sheet, ensureSubscribedType, SubscribeAndRetry, Expands
+    Sheet, ensureSubscribedType, SubscribeAndRetry, Expands, AsyncDropdown
 )
 
 from object_database import (
@@ -293,6 +293,21 @@ class GraphDisplayService(ServiceBase):
         return {"feigenbaum": {'x': numpy.concatenate([values]*(len(fvals)//len(values))), 'y': fvals, 'type': 'scattergl',
                 'mode': 'markers', 'opacity': .5, 'marker': {'size': 2}}}
 
+
+class DropdownTestService(ServiceBase):
+    def initialize(self):
+        pass
+
+    @staticmethod
+    def serviceDisplay(serviceObject, instance=None, objType=None, queryArgs=None):
+        return Card(
+            AsyncDropdown(DropdownTestService.delayAndDisplay)
+        )
+
+    @staticmethod
+    def delayAndDisplay():
+        time.sleep(3)
+        return Text('NOW WE HAVE LOADED')
 
 happy = Schema("core.test.happy")
 @happy.define

--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -309,7 +309,10 @@ class DropdownTestService(ServiceBase):
         time.sleep(1)
         return Text('NOW WE HAVE LOADED')
 
+
 happy = Schema("core.test.happy")
+
+
 @happy.define
 class Happy:
     i = int

--- a/object_database/web/cells/__init__.py
+++ b/object_database/web/cells/__init__.py
@@ -56,7 +56,8 @@ from object_database.web.cells.cells import (
     Sheet,
     Plot,
     _PlotUpdater,
-    AsyncDropdown
+    AsyncDropdown,
+    CircleLoader
 )
 
 from object_database.web.cells.CellsTestMixin import CellsTestMixin

--- a/object_database/web/cells/__init__.py
+++ b/object_database/web/cells/__init__.py
@@ -56,6 +56,7 @@ from object_database.web.cells.cells import (
     Sheet,
     Plot,
     _PlotUpdater,
+    AsyncDropdown
 )
 
 from object_database.web.cells.CellsTestMixin import CellsTestMixin

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -1456,6 +1456,7 @@ class Dropdown(Cell):
         fun = self.headersAndLambdas[msgFrame['ix']][1]
         fun()
 
+
 class AsyncDropdown(Cell):
     """A Bootstrap-styled Dropdown Cell
 
@@ -1523,18 +1524,18 @@ class AsyncDropdown(Cell):
         )
 
     def getInlineScript(self):
-       """Binds a specific call to the JS
-       side `cellHandler` who now has a
-       special method for dealing with initial
-       dropdown events. We dynamically pass the
-       Cell identity as the arg and add this as
-       an `onclick` inline method to the
-       Dropdown's `button` element
-       """
-       template = """
-       cellHandler.dropdownInitialBindFor('__target__')
-       """.replace('__target__', self.identity)
-       return template
+        """Binds a specific call to the JS
+        side `cellHandler` who now has a
+        special method for dealing with initial
+        dropdown events. We dynamically pass the
+        Cell identity as the arg and add this as
+        an `onclick` inline method to the
+        Dropdown's `button` element
+        """
+        template = """
+        cellHandler.dropdownInitialBindFor('__target__')
+        """.replace('__target__', self.identity)
+        return template
 
     def onMessage(self, messageFrame):
         """On `dropdown` events sent to this
@@ -1543,6 +1544,7 @@ class AsyncDropdown(Cell):
         """
         if messageFrame['event'] == 'dropdown':
             self.slot.set(not messageFrame['isOpen'])
+
 
 class AsyncDropdownContent(Cell):
     """A dynamic content cell designed for use
@@ -1609,6 +1611,7 @@ class AsyncDropdownContent(Cell):
             .set_attribute('id', elementId)
             .add_child(HTMLTextContent(str(self.identity)))
             .add_child(HTMLTextContent('____contents__')))
+
 
 class Container(Cell):
     def __init__(self, child=None):

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -1516,7 +1516,7 @@ class AsyncDropdown(Cell):
                 .set_attribute('data-firstclick', 'true'),
 
                 HTMLElement.div()
-                .set_attribute('id', '%s-dropdownContentWrapper')
+                .set_attribute('id', '%s-dropdownContentWrapper' % self.identity)
                 .add_classes(['dropdown-menu'])
                 .add_child(HTMLTextContent('____contents__'))
             )

--- a/object_database/web/cells/cells_test.py
+++ b/object_database/web/cells/cells_test.py
@@ -20,6 +20,7 @@ from object_database.web.cells import (
     Card,
     CardTitle,
     Cells,
+    CircleLoader,
     Clickable,
     Code,
     CodeEditor,
@@ -444,7 +445,7 @@ class CellsHTMLTests(unittest.TestCase):
         def handler():
             return Text("RESULT")
 
-        cell = AsyncDropdown(handler)
+        cell = AsyncDropdown('Untitled', handler)
         cell.cells = self.cells
 
         # Initial render
@@ -457,12 +458,19 @@ class CellsHTMLTests(unittest.TestCase):
         def handler():
             return Text("RESULT")
 
-        cell = AsyncDropdown(handler)
+        cell = AsyncDropdown('Untitled', handler)
         cell.cells = self.cells
 
         # Async changed render
         cell.recalculate()
         cell.slot.set(True)
+        html = cell.contents
+        self.assertHTMLNotEmpty(html)
+        self.assertHTMLValid(html)
+
+    def test_circle_loeader_html_valid(self):
+        cell = CircleLoader()
+        cell.recalculate()
         html = cell.contents
         self.assertHTMLNotEmpty(html)
         self.assertHTMLValid(html)
@@ -794,7 +802,7 @@ class CellsTests(unittest.TestCase):
         def handler():
             return changedCell
 
-        dropdown = AsyncDropdown(handler)
+        dropdown = AsyncDropdown('Untitled', handler)
         dropdown.contentCell.loadingCell = Text("INITIAL")
         self.cells.withRoot(dropdown)
         self.cells.renderMessages()

--- a/object_database/web/cells/cells_test.py
+++ b/object_database/web/cells/cells_test.py
@@ -70,7 +70,6 @@ from py_w3c.validators.html.validator import HTMLValidator
 import logging
 import unittest
 import threading
-import time
 
 test_schema = Schema("core.web.test")
 
@@ -791,6 +790,7 @@ class CellsTests(unittest.TestCase):
         open state.
         """
         changedCell = Text("Changed")
+
         def handler():
             return changedCell
 

--- a/object_database/web/cells/cells_test.py
+++ b/object_database/web/cells/cells_test.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 from object_database.web.cells import (
+    AsyncDropdown,
     Badge,
     Button,
     ButtonGroup,
@@ -69,6 +70,7 @@ from py_w3c.validators.html.validator import HTMLValidator
 import logging
 import unittest
 import threading
+import time
 
 test_schema = Schema("core.web.test")
 
@@ -439,6 +441,33 @@ class CellsHTMLTests(unittest.TestCase):
         self.assertHTMLNotEmpty(html)
         self.assertHTMLValid(html)
 
+    def test_async_dropdown_initial_html_valid(self):
+        def handler():
+            return Text("RESULT")
+
+        cell = AsyncDropdown(handler)
+        cell.cells = self.cells
+
+        # Initial render
+        cell.recalculate()
+        html = cell.contents
+        self.assertHTMLNotEmpty(html)
+        self.assertHTMLValid(html)
+
+    def test_async_dropdown_changed_html_valid(self):
+        def handler():
+            return Text("RESULT")
+
+        cell = AsyncDropdown(handler)
+        cell.cells = self.cells
+
+        # Async changed render
+        cell.recalculate()
+        cell.slot.set(True)
+        html = cell.contents
+        self.assertHTMLNotEmpty(html)
+        self.assertHTMLValid(html)
+
 
 class CellsTests(unittest.TestCase):
     @classmethod
@@ -754,3 +783,27 @@ class CellsTests(unittest.TestCase):
         self.assertTrue(self.cells.findChildrenByTag("large display 1"))
         self.assertTrue(self.cells.findChildrenByTag("sized display 2"))
         self.assertTrue(self.cells.findChildrenByTag("display 3"))
+
+    def test_async_dropdown_changes(self):
+        """Ensure that AsyncDropdown shows
+        the loading child first, then the
+        rendered child after changing the
+        open state.
+        """
+        changedCell = Text("Changed")
+        def handler():
+            return changedCell
+
+        dropdown = AsyncDropdown(handler)
+        dropdown.contentCell.loadingCell = Text("INITIAL")
+        self.cells.withRoot(dropdown)
+        self.cells.renderMessages()
+
+        # Initial
+        self.assertTrue(dropdown in self.cells)
+        self.assertTrue(dropdown.contentCell.loadingCell in self.cells)
+
+        # Changed
+        dropdown.slot.set(True)
+        self.cells.renderMessages()
+        self.assertTrue(changedCell in self.cells)

--- a/object_database/web/content/CellHandler.js
+++ b/object_database/web/content/CellHandler.js
@@ -172,7 +172,6 @@ class CellHandler {
                 if(target != null){
                     target.parentNode.replaceChild(source, target);
                 } else {
-                    debugger;
                     console.log("In message ", message, " couldn't find ", replacementKey);
                 }
             });

--- a/object_database/web/content/CellHandler.js
+++ b/object_database/web/content/CellHandler.js
@@ -194,4 +194,55 @@ class CellHandler {
         element.innerHTML = html;
         return element.children[0];
     }
+
+    /**
+     * This is a (hopefully temporary) hack
+     * that will intercept the first time a
+     * dropdown carat is clicked and bind
+     * Bootstrap Dropdown event handlers
+     * to it that should be bound to the
+     * identified cell. We are forced to do this
+     * because the current Cells infrastructure
+     * does not have flexible event binding/handling.
+     * @param {string} cellId - The ID of the cell
+     * to identify in the socket callback we will
+     * bind to open and close events on dropdown
+     */
+    dropdownInitialBindFor(cellId){
+        let elementId = cellId + '-dropdownMenuButton';
+        let element = document.getElementById(elementId);
+        if(!element){
+            throw Error('Element of id ' + elementId + ' doesnt exist!');
+        }
+        let dropdownMenu = element.parentElement;
+        let firstTimeClicked = element.dataset.firstclick == 'true';
+        if(firstTimeClicked){
+            $(dropdownMenu).on('show.bs.dropdown', function(){
+                cellSocket.sendString(JSON.stringify({
+                    event: 'dropdown',
+                    target_cell: cellId,
+                    isOpen: false
+                }));
+            });
+            $(dropdownMenu).on('hide.bs.dropdown', function(){
+                cellSocket.sendString(JSON.stringify({
+                    event: 'dropdown',
+                    target_cell: cellId,
+                    isOpen: true
+                }));
+            });
+
+            // Now expire the first time clicked
+            element.dataset.firstclick = 'false';
+        }
+    }
+
+    /**
+     * Unsafely executes any passed in string
+     * as if it is valid JS against the global
+     * window state.
+     */
+    static unsafelyExecute(aString){
+        window.exec(aString);
+    }
 }

--- a/object_database/web/content/page.html
+++ b/object_database/web/content/page.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<meta name="viewport" content="width=device-width, initial-scale=1">
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
-      integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
-    crossorigin="anonymous">
+        <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
+             integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
+             crossorigin="anonymous">-->
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.2/ace.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.2/ext-language_tools.js"></script>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR implements an `AsyncDropdown` Cell, which is a `Dropdown` that can dynamically load the displayed contents when the dropdown is opened (as opposed to generating those contents ahead of time).
  
## Motivation and Context
<!-- Why is this change required? -->
Not only is it useful to be able to put arbitrary elements inside of a Dropdown, but because some Cells require computation on the back end that could take a bit of time (relative to other UI components), it's helpful to load those inner Cells dynamically when the user opens the dropdown.

## Approach
### How it Works ###
We introduce two new Cell types, `AsyncDropdown` and `AsyncDropdownContent`. The latter should not be used directly, but is instead created and bound to the former at instantiation.
  
An `AsyncDropdown` cell takes a function as it's constructor argument. We expect this function to do some kind of computation, after which it returns a Cell or Cell structure that can be displayed (that's the asynchronous part). We make use of a special `Slot` that tracks whether or not the dropdown is in the open position. When this changes to open, `AsyncDropdown` will pass that information to its child `AsyncDropdownContent` component and tell it to call the passed display function (which is bound to a `Subscribed` Cell). If that passed function is working correctly, voila, the new content is displayed.
 
**Note that this implementation is a bit hacky, due to event binding difficulties outlined in the sections below**.
  
### Caveat: Front End and Event Binding Issues ###
The biggest difficulty in implementing this component was adding event binding to "know" when the dropdown, which is a Bootstrap Dropdown, had opened or closed. The problem extends from the lifecycle structure of `Cell` objects themselves, the current protocol on the websocket, and how elements are handled on the front end. As it stands, there is no uniform way to bind events to a Cell when it gets inserted to the DOM besides inlining callbacks into event handlers directly in the HTML (ie `<div onclick="<some-js-here>"></div>`.  This is not flexible enough for building complex UIs.
  
For now, we've implemented a hacky way of doing this, by adding a special method to the global `cellHandler` object on the JS side. It is defined [here](https://github.com/APrioriInvestments/nativepython/blob/eric-component-1/object_database/web/content/CellHandler.js#L211). Because we need to add listeners for the Bootstrap `show` and `hide` events but have no way of doing that naturally with Cells, we instead bind this `dropdownInitialBindFor` method to the `onclick` inline click handler for the dropdown's button element. It checks to see if it is the first time that its click event has fired. If so, it binds handlers for the Bootstrap events. If not, it does nothing. This ensures that we can receive reverse messages from the UI to the Cell whenever the dropdown opens or closes.

Another related issue dealt with knowing when to re-render specific parts of the dropdown. Unlike the existing `Dropdown` cell, we cannot just re-send HTML for the cell over the wire each time, because we care about when it opens or closes and we update child cells based upon those events. To `recalculate` each time means inserting a whole new dropdown and those always render with their menus closed initially. A mix of slot use and separating the dropdown into two constituent Cells seemed to do the trick here, once we got event binding working well.
  
This implementation is fairly complicated. A refactored Cells lifecycle, WS protocol, and DOM handling pattern could greatly improve the implementation of this component and others. We have some [working notes on this possibility available here](https://gist.github.com/darth-cheney/4b5451c8bcaf31ff1f2d5765a83c7310). Otherwise we run the risk of adding incredibly specific methods to `CellHandler` for each unique type of `Cell` we create, which can get out of control quickly.
  
### Try it Yourself ###
We have created a [`DropdownTestService`](https://github.com/APrioriInvestments/nativepython/blob/eric-component-1/object_database/service_manager/ServiceManager_test.py#L297) and added it to the basic service testing application at `frontends/object_database_webtest.py`.
  
In the example, opening the menu will show a loading display, trigger a callback that waits for 1 second and then displays the completed result.
  
### Incomplete ###
This PR is not quite complete. We need to add flexibility to allow the Dropdown to take a custom loading display cell, as well as a text label for the dropdown. For now, we wanted to start a review/discussion of the implementation before finalizing anything.
<!-- Describe your changes in reasonable detail -->

## How Has This Been Tested?
In addition to the live `DropdownTestService` mentioned above, we have added a couple of tests that ensure behavior is correct from the Cells side of things.
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.