### PR TITLE
VDom (maquette) integration 1

### DIFF
--- a/experiments/maquette/dom.py
+++ b/experiments/maquette/dom.py
@@ -1,0 +1,29 @@
+""" an example of a dict/json dom representation """
+
+socketData = {
+    "tag": "div",
+    "attrs": {
+        "style": "background-color:gray; height: 700px",
+    },
+    "children": [
+        {
+            "tag": "div",
+            "attrs": {
+                "style": "text-align:center; width:100%",
+                "id": "test-id"
+            },
+            "children": [
+                {
+                    "tag": "h1",
+                    "attrs": {"style": "color:blue"},
+                    "children": ["nested child"]
+                },
+                {
+                    "tag": "h1",
+                    "attrs": {"style": "color:black"},
+                    "children": ["another nested child"]
+                }
+            ]
+        }
+    ]
+}

--- a/experiments/maquette/package.json
+++ b/experiments/maquette/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "maquette-typescript-jsx-starter",
+  "version": "1.0.0",
+  "description": "",
+  "main": "gulpfile.js",
+  "dependencies": {
+    "maquette": "3.3.3",
+    "socket.io": "^2.2.0"
+  },
+  "devDependencies": {
+    "maquette-jsx": "3.0.0",
+    "ts-loader": "5.3.3",
+    "typescript-assistant": "0.37.4",
+    "webpack": "^4.29.5",
+    "webpack-cli": "3.2.3",
+    "webpack-dev-middleware": "3.6.0",
+    "webpack-dev-server": "^3.2.1"
+  },
+  "scripts": {
+    "serve": "webpack-dev-server"
+  },
+  "license": "MIT"
+}

--- a/experiments/maquette/public/index.html
+++ b/experiments/maquette/public/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+ <head>
+   <title>Maquette typescript Example</title>
+ </head>
+ <body>
+   <script src="bundle.js"></script>
+	 <script type="text/javascript" charset="utf-8">
+			// var socket = io.connect('http://' + document.domain + ':' + location.port);
+		  // socket.on('connect', function() {
+			// 	socket.emit('my event', {data: 'I\'m connected!'});
+			//});
+			// socket = new window.WebSocket('ws://localhost:8080/')
+	 </script>
+ </body>
+</html>

--- a/experiments/maquette/socket_test.py
+++ b/experiments/maquette/socket_test.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# basic socket io setup
+
+from flask import Flask, jsonify  # , render_template
+from flask_socketio import SocketIO, emit
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'secret!'
+socketio = SocketIO(app)
+
+
+@socketio.on('message')
+def handle_message(message):
+    print('received message: ' + str(message))
+
+
+@socketio.on('init')
+def handle_init():
+    import dom
+    emit('init', dom.socketData)
+
+
+if __name__ == '__main__':
+    socketio.run(app, debug=True)

--- a/experiments/maquette/socket_test.py
+++ b/experiments/maquette/socket_test.py
@@ -2,7 +2,7 @@
 
 # basic socket io setup
 
-from flask import Flask, jsonify  # , render_template
+from flask import Flask  # jsonify , render_template
 from flask_socketio import SocketIO, emit
 
 app = Flask(__name__)

--- a/experiments/maquette/src/application.js
+++ b/experiments/maquette/src/application.js
@@ -1,0 +1,68 @@
+import * as maquette from 'maquette';
+import io from 'socket.io-client'
+
+var projector = maquette.createProjector();
+
+// set up a basic socket
+var socket = io.connect('ws://localhost:5000');
+socket.on('connect', function() {
+	socket.emit('message', {message: 'I\'m connected!'});
+});
+
+
+// load initial data
+var socketData = {
+	tag: "div",
+	attrs: {id: 'test-id', style: "height:500px"},
+	children: ['ok']
+};
+
+
+// we are sticking with maquette notation and style
+var h = maquette.h;
+
+
+function poll() {
+    socket.emit("init");
+    socket.on("init", function(data) {
+        socketData = data;
+        
+        projector.scheduleRender();
+    });
+}
+
+
+function generate(data) {
+	if (data === undefined) {
+		return h('div', ["no data"]);
+	}
+	if (data["children"].length == 1){
+		let child = data["children"][0];
+		if (typeof(child) === "string") {
+			return ( 
+				h(data["tag"], data["attrs"], data["children"])
+			)
+		} else {
+			return h(data["tag"], data["attrs"], [generate(child)])
+		}
+	} else {
+		let children = data["children"].map((c) => generate(c));
+		return ( 
+			h(data["tag"], data["attrs"], children)	
+		)
+	}
+}
+
+// Initializes the projector 
+document.addEventListener('DOMContentLoaded', function () {
+	projector.append(document.body, render);
+});
+
+document.addEventListener('DOMContentLoaded', function () {
+	projector.replace(document.getElementById("test-id"), render);
+    setInterval(poll, 500);
+});
+
+export function render() {
+	return generate(socketData) 
+}

--- a/experiments/maquette/tsconfig.json
+++ b/experiments/maquette/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5",
+    "strict": true,
+    "outDir": "build/js",
+    "rootDir": ".",
+    "sourceMap": true,
+    "jsx": "react",
+    "jsxFactory": "jsx"
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/experiments/maquette/webpack.config.js
+++ b/experiments/maquette/webpack.config.js
@@ -1,0 +1,28 @@
+module.exports = {
+  entry: './src/application.js',
+  output: {
+    path: __dirname + '/build/webpack',
+    filename: 'bundle.js'
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        loader: 'ts-loader',
+        exclude: /node_modules/,
+        options: {
+          transpileOnly: true
+        }
+      }
+    ]
+  },
+  devServer: {
+    contentBase: [
+      'public'
+    ]
+  },
+  mode: 'development'
+};

--- a/object_database/web/content/CellHandler.js
+++ b/object_database/web/content/CellHandler.js
@@ -12,14 +12,14 @@
 
 class CellHandler {
     constructor(h, projector){
-		// props
-		this.h = h;
-		this.projector = projector;
+	// props
+	this.h = h;
+	this.projector = projector;
 
         // Instance Props
         this.postscripts = [];
         this.cells = {};
-		this.DOMParser = new DOMParser();
+	this.DOMParser = new DOMParser();
 
         // Bind Instance Methods
         this.showConnectionClosed = this.showConnectionClosed.bind(this);
@@ -35,8 +35,10 @@ class CellHandler {
      * disconnected.
      */
     showConnectionClosed(){
-		this.projector.replace(document.getElementById("page_root"),
-			this.connectionClosedView)
+	this.projector.replace(
+            document.getElementById("page_root"),
+	    this.connectionClosedView
+        );
     }
 
     /**
@@ -124,25 +126,25 @@ class CellHandler {
             this.cells["holding_pen"] = document.getElementById("holding_pen");
         }
 
-		// With the exception of `page_root` and `holding_pen` id nodes, all
-		// elements in this.cells are virtual. Dependig on whether we are adding a
-		// new node, or manipulating an existing, we neeed to work with the underlying
-		// DOM node. Hence if this.cell[message.id] is a vdom element we use its 
-		// underlying domNode element when in operations like this.projector.replace()
-		let cell = this.cells[message.id];
-		if (cell !== undefined && cell.domNode !== undefined) {
-			cell = cell.domNode;
-		}
+	// With the exception of `page_root` and `holding_pen` id nodes, all
+	// elements in this.cells are virtual. Dependig on whether we are adding a
+	// new node, or manipulating an existing, we neeed to work with the underlying
+	// DOM node. Hence if this.cell[message.id] is a vdom element we use its
+	// underlying domNode element when in operations like this.projector.replace()
+	let cell = this.cells[message.id];
+	if (cell !== undefined && cell.domNode !== undefined) {
+	    cell = cell.domNode;
+	}
 
         if(message.discard !== undefined){
-			// Instead of removing the node we replace with the a
-			// `display:none` style node which effectively removes it
-			// from the DOM
-			if (cell.parentNode !== null) {
-				this.projector.replace(cell, () => {
-					return h("div", {style: "display:none"}, []); 
-				});
-			}
+	    // Instead of removing the node we replace with the a
+	    // `display:none` style node which effectively removes it
+	    // from the DOM
+	    if (cell.parentNode !== null) {
+		this.projector.replace(cell, () => {
+		    return h("div", {style: "display:none"}, []);
+		});
+	    }
         } else if(message.id !== undefined){
             // A dictionary of ids within the object to replace.
             // Targets are real ids of other objects.
@@ -154,21 +156,25 @@ class CellHandler {
                 // This is a totally new node.
                 // For the moment, add it to the
                 // holding pen.
-				this.projector.append(this.cells["holding_pen"], () => {return velement})
+		this.projector.append(this.cells["holding_pen"], () => {
+                    return velement;
+                });
                 this.cells[message.id] = velement;
             } else {
                 // Replace the existing copy of
                 // the node with this incoming
                 // copy.
                 if(cell.parentNode === null){
-					this.projector.append(this.cells["holding_pen"], () => {return velement})
+		    this.projector.append(this.cells["holding_pen"], () => {
+                        return velement;
+                    });
                 } else {
-					this.projector.replace(cell, () => {return velement})
-				}
-			}
+		    this.projector.replace(cell, () => {return velement});
+		}
+	    }
             this.cells[message.id] = velement;
 
-            // Now wire in replacements 
+            // Now wire in replacements
             Object.keys(replacements).forEach((replacementKey, idx) => {
                 let target = document.getElementById(replacementKey);
                 let source = null;
@@ -176,16 +182,20 @@ class CellHandler {
                     // This is actually a new node.
                     // We'll define it later in the
                     // event stream.
-					source = this.h("div", {id: replacementKey}, [])
+		    source = this.h("div", {id: replacementKey}, []);
                     this.cells[replacements[replacementKey]] = source; 
-					this.projector.append(this.cells["holding_pen"], () => {return source})
+		    this.projector.append(this.cells["holding_pen"], () => {
+                        return source;
+                    });
                 } else {
                     // Not a new node
                     source = this.cells[replacements[replacementKey]];
                 }
 
                 if(target != null){
-					this.projector.replace(target, () => {return source});
+		    this.projector.replace(target, () => {
+                        return source;
+                    });
                 } else {
                     console.log("In message ", message, " couldn't find ", replacementKey);
                 }
@@ -199,51 +209,50 @@ class CellHandler {
 
     /**
      * Helper function that generates the vdom Node for
-	 * to be display when connection closes
+     * to be display when connection closes
      */
     connectionClosedView(){
-		return this.h("main.container", {role: "main"}, [
-			this.h("div", {class: "alert alert-primary center-block mt-5"}, [
-				"Disconnected"
-			])
-		])
+	return this.h("main.container", {role: "main"}, [
+	    this.h("div", {class: "alert alert-primary center-block mt-5"}, [
+		"Disconnected"
+	    ])
+	]);
     }
 
     /**
      * Helper function that takes some incoming
      * HTML string and returns a maquette hyperscript
-	 * VDOM element from it.
-	 * This uses the internal browser DOMparser() to generate the html
-	 * structure from the raw string and then recursively build the 
-	 * VDOM element
+     * VDOM element from it.
+     * This uses the internal browser DOMparser() to generate the html
+     * structure from the raw string and then recursively build the 
+     * VDOM element
      * @param {string} html - The markup to
      * transform into a real element.
      */
     htmlToVDomEl(html, id){
-		let dom = this.DOMParser.parseFromString(html, "text/html")
+	let dom = this.DOMParser.parseFromString(html, "text/html");
         let element = dom.body.children[0];
         return this._domElToVdomEl(element, id);
     }
 
-	_domElToVdomEl(domEl, id) {
-		let tagName = domEl.tagName.toLocaleLowerCase();
-		let attrs = {id: id}
-		let index;
-		for (index = 0; index < domEl.attributes.length; index++){
-			let item = domEl.attributes.item(index)
-			attrs[item.name] = item.value.trim();
-		}
-
-		if (domEl.childElementCount === 0) {
-			return h(tagName, attrs, [domEl.textContent])
-		}
-		
-		let children = [];
-		for (index = 0; index < domEl.children.length; index++){
-			let child = domEl.children[index]
-			children.push(this._domElToVdomEl(child));
-		}
-		return h(tagName, attrs, children);
+    _domElToVdomEl(domEl, id) {
+	let tagName = domEl.tagName.toLocaleLowerCase();
+	let attrs = {id: id};
+	let index;
+	for (index = 0; index < domEl.attributes.length; index++){
+	    let item = domEl.attributes.item(index);
+	    attrs[item.name] = item.value.trim();
 	}
 
+	if (domEl.childElementCount === 0) {
+	    return h(tagName, attrs, [domEl.textContent]);
+	}
+
+	let children = [];
+	for (index = 0; index < domEl.children.length; index++){
+	    let child = domEl.children[index];
+	    children.push(this._domElToVdomEl(child));
+	}
+	return h(tagName, attrs, children);
+    }
 }

--- a/object_database/web/content/CellHandler.js
+++ b/object_database/web/content/CellHandler.js
@@ -19,6 +19,7 @@ class CellHandler {
         // Instance Props
         this.postscripts = [];
         this.cells = {};
+		this.DOMParser = new DOMParser();
 
         // Bind Instance Methods
         this.showConnectionClosed = this.showConnectionClosed.bind(this);
@@ -181,7 +182,6 @@ class CellHandler {
                     target.parentNode.replaceChild(source, target);
 					// this.projector.replace(source, () => {return h(target)});
                 } else {
-                    debugger;
                     console.log("In message ", message, " couldn't find ", replacementKey);
                 }
             });
@@ -202,6 +202,7 @@ class CellHandler {
     htmlToDomEl(html){
         let element = document.createElement("div");
         element.innerHTML = html;
+		this.htmlToVDomEl(html);
         return element.children[0];
     }
 
@@ -216,4 +217,42 @@ class CellHandler {
 			])
 		])
     }
+
+    /**
+     * Helper function that takes some incoming
+     * HTML string and returns a maquette hyperscript
+	 * VDOM element from it.
+	 * This uses the internal browser DOMparser() to generate the html
+	 * structure from the raw string and then recursively build the 
+	 * VDOM element
+     * @param {string} html - The markup to
+     * transform into a real element.
+     */
+    htmlToVDomEl(html){
+		let dom = this.DOMParser.parseFromString(html, "text/html")
+        let element = dom.body.children[0];
+        return this._domElToVdomEl(element);
+    }
+
+	_domElToVdomEl(domEl) {
+		let tagName = domEl.tagName.toLocaleLowerCase();
+		let attrs = {}
+		let index;
+		for (index = 0; index < domEl.attributes.length; index++){
+			let item = domEl.attributes.item(index)
+			attrs[item.name] = item.value;
+		}
+
+		if (domEl.childElementCount === 0) {
+			return h(tagName, attrs, [domEl.textContent])
+		}
+		
+		let children = [];
+		for (index = 0; index < domEl.children.length; index++){
+			let child = domEl.children[index]
+			children.push(this._domElToVdomEl(child));
+		}
+		return h(tagName, attrs, children);
+	}
+
 }

--- a/object_database/web/content/CellHandler.js
+++ b/object_database/web/content/CellHandler.js
@@ -167,7 +167,6 @@ class CellHandler {
 				}
 			}
             this.cells[message.id] = velement;
-		}
 
             // Now wire in replacements 
             Object.keys(replacements).forEach((replacementKey, idx) => {

--- a/object_database/web/content/page.html
+++ b/object_database/web/content/page.html
@@ -9,6 +9,7 @@
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.2/ace.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.2/ext-language_tools.js"></script>
+<script src="https://unpkg.com/maquette@3.3.0/dist/maquette.umd.js"></script>
 
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/handsontable/6.2.2/handsontable.full.css"></link>
 
@@ -24,16 +25,43 @@
 <link rel="stylesheet" href="/content/object_database.css"/>
 
 <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 <script src="/content/CellSocket.js"></script>
 <script src="/content/CellHandler.js"></script>
 
 <script>
+	// This is the initial render function. It is called when "DOMContentLoaded"
+	// event is fired with the actual rendering handled by the maquette.projector
+	// (see below under `document.addEventListener('DOMContentLoaded',...)`
+	// TODO: potentially this should all be moved to CellHandler
+	function render() {
+		return h("div", {}, [
+			h("div", {id: "page_root"}, [
+				h("div.container-fluid", {}, [
+					h("div.card", {class: "mt-5"}, [
+						h("div.card-body", {}, ["Loading..."])
+					])
+				])
+			]),
+			h("div", {id: "holding_pen", style: "display:none"}, [])
+		])
+	}
+</script>
+
+<script>
+ // maquette vdom setup
+ // maquette.h is the maquette virtual hyperscript func for vdom interaction 
+ var h = maquette.h;
+ var projector = maquette.createProjector();
+
  var langTools = ace.require("ace/ext/language_tools");
  var aceEditors = {};
  var handsOnTables = {}; // Not sure what this is or where it's used
  
  const cellSocket = new CellSocket();
- const cellHandler = new CellHandler();
+ const cellHandler = new CellHandler(h, projector);
  cellSocket.onPostscripts(cellHandler.handlePostscript);
  cellSocket.onMessage(cellHandler.handleMessage);
  cellSocket.onClose(cellHandler.showConnectionClosed);
@@ -41,9 +69,13 @@
      console.error("SOCKET ERROR: ", err);
  });
  document.addEventListener('DOMContentLoaded', () => {
+	   projector.append(document.body, render);
      cellSocket.connect();
  });
 
+</script>
+
+<script>
  function mapPlotlyData(d) {
      if (d.timestamp !== undefined) {
          d.timestamp = unpackHexFloats(d.timestamp)
@@ -89,28 +121,7 @@
 
      return new Float64Array(buf)
  }
- 
 </script>
-</head>
-<body>
-<div id="page_root">
-  <div class="container-fluid">
-    <div class="card mt-5">
-      <div class="card-body">
-        Loading...
-      </div>
-    </div>
-  </div>
-</div>
-
-<div id='holding_pen' style="display:none"></div>
-
-<script
-  src="https://code.jquery.com/jquery-3.3.1.min.js"
-  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
-  crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 
 <script>
 $(function () {
@@ -132,5 +143,10 @@ $('[data-poload]').on('show.bs.dropdown', function (arg) {
 })
 
 </script>
+</head>
+
+<!-- END OF SCRIPTS -->
+
+<body>
 </body>
-<html>
+</html>

--- a/object_database/web/content/page.html
+++ b/object_database/web/content/page.html
@@ -32,22 +32,22 @@
 <script src="/content/CellHandler.js"></script>
 
 <script>
-	// This is the initial render function. It is called when "DOMContentLoaded"
-	// event is fired with the actual rendering handled by the maquette.projector
-	// (see below under `document.addEventListener('DOMContentLoaded',...)`
-	// TODO: potentially this should all be moved to CellHandler
-	function render() {
-		return h("div", {}, [
-			h("div", {id: "page_root"}, [
-				h("div.container-fluid", {}, [
-					h("div.card", {class: "mt-5"}, [
-						h("div.card-body", {}, ["Loading..."])
-					])
-				])
-			]),
-			h("div", {id: "holding_pen", style: "display:none"}, [])
-		])
-	}
+ // This is the initial render function. It is called when "DOMContentLoaded"
+ // event is fired with the actual rendering handled by the maquette.projector
+ // (see below under `document.addEventListener('DOMContentLoaded',...)`
+ // TODO: potentially this should all be moved to CellHandler
+ function render() {
+     return h("div", {}, [
+	 h("div", {id: "page_root"}, [
+	     h("div.container-fluid", {}, [
+		 h("div.card", {class: "mt-5"}, [
+		     h("div.card-body", {}, ["Loading..."])
+		 ])
+	     ])
+	 ]),
+	 h("div", {id: "holding_pen", style: "display:none"}, [])
+     ]);
+ }
 </script>
 
 <script>

--- a/object_database/web/content/page.html
+++ b/object_database/web/content/page.html
@@ -75,6 +75,8 @@
 
 </script>
 
+<!-- Helper functions; TODO: should likely be moved or integrated elsewhere -->
+
 <script>
  function mapPlotlyData(d) {
      if (d.timestamp !== undefined) {


### PR DESCRIPTION
This PR is part of the ongoing process to improve both the communication (WS) protocol and client side rendering framework. The main change here is the introduction of a virtual DOM js library, [maquette](https://maquettejs.org/), with minimal changes to the current setup. 

## Motivation and Context
There are a number of [good reasons](https://www.accelebrate.com/blog/the-real-benefits-of-the-virtual-dom-in-react-js/) to use a virtual DOM setup. From our standpoint, we would like to ensure efficiency in browser rendering on DOM changes as well as a simple, lightweight, API that will be the foundation of a unified WS protocol (see [here](https://gist.github.com/darth-cheney/4b5451c8bcaf31ff1f2d5765a83c7310) for a draft)). 

Additional motivation include a simplified client-side setup to allow for better event binding, callbacks and debugging (see discussion in [this PR](https://github.com/APrioriInvestments/nativepython/pull/89)). 

[Maquette](https://github.com/APrioriInvestments/nativepython/pull/89) is very lightweight, has great documentation, and is designed to do just this sort of thing and do it well.

## Approach
All interaction with the DOM is now handled by the maquette library. All html coming over the WS is [converted](https://github.com/APrioriInvestments/nativepython/blob/daniel-maquette/object_database/web/content/CellHandler.js#L222) to a maquette vdom element and all updates, appends and replacements are handled by the maquette [projector](https://maquettejs.org/typedoc/interfaces/projector.html). 

**Note**: the general client-side rendering and logic has **not** been altered. For example, the two caches designed to deal with DOM interactions are still present: 
* [this.cells](https://github.com/APrioriInvestments/nativepython/blob/daniel-maquette/object_database/web/content/CellHandler.js#L21) (designed to keep copies of content, some rendered, some to be rendered DOM elements) and  
* [div[id="holding_pen"]](https://github.com/APrioriInvestments/nativepython/blob/daniel-maquette/object_database/web/content/page.html#L48) (designed to allow for "off-screen" DOM element manipulation). 

Neither of these is effectively changed from a logic standpoint. In addition, raw html is still coming across the wire now converted to vdom elements. The goal is to have minimal impact on anything server-side, making an incremental change, but also not avoid development which will become moot with near future changes. 

After this PR, the next steps should involve updating the WS protocol to send structured (json) data, as described [here](https://gist.github.com/darth-cheney/4b5451c8bcaf31ff1f2d5765a83c7310), simplify the protocol itself, and remove the multiple DOM caches with their respective logic to allow for a simple DOM update API. 

## How Has This Been Tested?
Development has been client-side only and testing was done by inspecting the [object_database_webtest.py](https://github.com/APrioriInvestments/nativepython/blob/daniel-maquette/object_database/frontends/object_database_webtest.py) application. 


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Framework refactoring. 

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
(only inline documentation has been updated)