### PR TITLE
Working on direct c++ Alternative type; cpptests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,11 @@ generatetesttypes: $(TP_SRC_PATH)/generate_types.py
 	. $(VIRTUAL_ENV)/bin/activate; \
 	python3 $(TP_SRC_PATH)/generate_types.py --testTypes $(TP_SRC_PATH)/TestGeneratedTypes.hpp
 
+.PHONY: cpptests
+cpptests: $(TP_SRC_PATH)/direct_types_test.py
+	. $(VIRTUAL_ENV)/bin/activate; \
+	python3 $(TP_SRC_PATH)/direct_types_test.py --test
+
 .PHONY: clean
 clean:
 	rm -rf build/

--- a/typed_python/CompositeType.hpp
+++ b/typed_python/CompositeType.hpp
@@ -30,6 +30,10 @@ public:
             m_types(types),
             m_names(names)
     {
+        m_directNeedsResolution = false;
+        for (auto& typePtr: m_types)
+            if (typePtr->getTypeCategory() == catForward)
+                m_directNeedsResolution = true;
     }
 
     bool isBinaryCompatibleWithConcrete(Type* other);
@@ -112,6 +116,15 @@ public:
     const std::vector<std::string>& getNames() const {
         return m_names;
     }
+    void directResolveForward(Type* fwd, Type* target) {
+        if (m_directNeedsResolution) {
+            for (auto& typePtr: m_types)
+                if (typePtr == fwd)
+                    typePtr = target;
+            _forwardTypesMayHaveChanged();
+            m_directNeedsResolution = false;
+        }
+    }
 protected:
     template<class subtype>
     static subtype* MakeSubtype(const std::vector<Type*>& types, const std::vector<std::string>& names) {
@@ -134,6 +147,7 @@ protected:
     std::vector<Type*> m_types;
     std::vector<size_t> m_byte_offsets;
     std::vector<std::string> m_names;
+    bool m_directNeedsResolution;
 };
 
 class NamedTuple : public CompositeType {

--- a/typed_python/DirectTypes.hpp
+++ b/typed_python/DirectTypes.hpp
@@ -10,23 +10,18 @@ class String {
             return t;
         }
 
-        String() {
-            mLayout = nullptr;
-        }
+        String():mLayout(0) {}
 
-        explicit String(const char *pc) {
+        explicit String(const char *pc):mLayout(0) {
             getType()->constructor((instance_ptr)&mLayout, 1, strlen(pc), pc);
         }
 
-        explicit String(std::string& s) {
+        explicit String(std::string& s):mLayout(0) {
             getType()->constructor((instance_ptr)&mLayout, 1, s.length(), s.data());
         }
 
-        explicit String(StringType::layout* l) {
-            getType()->assign(
-               (instance_ptr)&mLayout,
-               (instance_ptr)&l
-               );
+        explicit String(StringType::layout* l):mLayout(0) {
+            getType()->constructor((instance_ptr)&mLayout, l->bytes_per_codepoint, l->pointcount, (const char*)l->data);
         }
 
         ~String() {
@@ -63,6 +58,54 @@ class String {
         StringType::layout* getLayout() const {
             return mLayout;
         }
+
+        static inline char cmp(const String& left, const String& right) {
+            return StringType::cmpStatic(left.mLayout, right.mLayout);
+        }
+        bool operator==(const String& right) { return cmp(*this, right) == 0; }
+        bool operator!=(const String& right) { return cmp(*this, right) != 0; }
+        bool operator<(const String& right) { return cmp(*this, right) < 0; }
+        bool operator>(const String& right) { return cmp(*this, right) > 0; }
+        bool operator<=(const String& right) { return cmp(*this, right) <= 0; }
+        bool operator>=(const String& right) { return cmp(*this, right) >= 0; }
+
+        static String concatenate(const String& left, const String& right) {
+            return String(StringType::concatenate(left.getLayout(), right.getLayout()));
+        }
+        String operator+(const String& right) {
+            return String(StringType::concatenate(mLayout, right.getLayout()));
+        }
+        String& operator+=(const String& right) {
+            return *this = String(StringType::concatenate(mLayout, right.getLayout()));
+        }
+        String upper() { return String(StringType::upper(mLayout)); }
+        String lower() { return String(StringType::lower(mLayout)); }
+        int64_t find(const String& sub, int64_t start, int64_t end) { return StringType::find(mLayout, sub.getLayout(), start, end); }
+        int64_t find(const String& sub, int64_t start) { return StringType::find(mLayout, sub.getLayout(), start, mLayout ? mLayout->pointcount : 0); }
+        int64_t find(const String& sub) { return StringType::find(mLayout, sub.getLayout(), 0, mLayout ? mLayout->pointcount : 0); }
+//        ListOf<String> split(const String& sep, int64_t max = -1) {
+//           ListOf<String> ret;
+//           StringType::split(ret.getType()->getLayout(), mLayout, sep.getLayout(), max);
+//           return ret;
+//        }
+//        ListOf<String> split(int64_t max = -1) {
+//           ListOf<String> ret;
+//           StringType::split_3(ret.getType()->getLayout(), mLayout, max);
+//           return ret;
+//        }
+        bool isalpha() { return StringType::isalpha(mLayout); }
+        bool isalnum() { return StringType::isalnum(mLayout); }
+        bool isdecimal() { return StringType::isdecimal(mLayout); }
+        bool isdigit() { return StringType::isdigit(mLayout); }
+        bool islower() { return StringType::islower(mLayout); }
+        bool isnumeric() { return StringType::isnumeric(mLayout); }
+        bool isprintable() { return StringType::isprintable(mLayout); }
+        bool isspace() { return StringType::isspace(mLayout); }
+        bool istitle() { return StringType::istitle(mLayout); }
+        bool isupper() { return StringType::isupper(mLayout); }
+
+        String substr(int64_t start, int64_t stop) { return String(StringType::getsubstr(mLayout, start, stop)); }
+
     private:
         StringType::layout* mLayout;
 };

--- a/typed_python/DirectTypes.hpp
+++ b/typed_python/DirectTypes.hpp
@@ -4,6 +4,229 @@
 #include "Type.hpp"
 #include "PyInstance.hpp"
 
+
+//templates for TupleOf, ListOf, Dict, ConstDict, OneOf
+template<class element_type>
+class ListOf {
+public:
+    static ListOfType* getType() {
+        static ListOfType* t = ListOfType::Make(TypeDetails<element_type>::getType());
+        return t;
+    }
+
+    static Type* getEltType() {
+        static Type* t = getType()->getEltType();
+        return t;
+    }
+
+    static ListOf<element_type> fromPython(PyObject* p) {
+        ListOfType::layout* l = nullptr;
+        PyInstance::copyConstructFromPythonInstance(getType(), (instance_ptr)&l, p, true);
+        return (ListOf<element_type>)l;
+    }
+
+    element_type& operator[](int64_t offset) {
+       return *(element_type*)((uint8_t*)mLayout->data + TypeDetails<element_type>::bytecount * offset);
+    }
+ 
+    const element_type& operator[](int64_t offset) const {
+       return *(element_type*)((uint8_t*)mLayout->data + TypeDetails<element_type>::bytecount * offset);
+    }
+
+    size_t size() const {
+        return !mLayout ? 0 : sizeof(*mLayout) + TypeDetails<element_type>::bytecount * mLayout->count;
+    }
+
+    size_t count() const {
+        return !mLayout ? 0 : mLayout->count;
+    }
+
+    void append(const element_type& e) {
+        getType()->append((instance_ptr)&mLayout, (instance_ptr)&e);
+    }
+
+    template<class buf_t>
+    void serialize(buf_t& buffer) {
+        getType()->serialize<buf_t>((instance_ptr)&mLayout, buffer);
+    }
+
+    template<class buf_t>
+    void deserialize(buf_t& buffer) {
+        getType()->deserialize<buf_t>((instance_ptr)&mLayout, buffer);
+    }
+
+    ListOf(): mLayout(0) {
+        getType()->constructor((instance_ptr)&mLayout);
+    }
+
+    ListOf(const std::vector<element_type>& v): mLayout(0) {
+        getType()->constructor((instance_ptr)&mLayout, v.size(),
+            [&](instance_ptr target, int64_t k) {
+                getEltType()->constructor(target);
+                getEltType()->assign(target, (instance_ptr)(&v[k]));
+            }
+        );
+    }
+
+    ListOf(const ListOf& other)
+    {
+        getType()->copy_constructor(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&other.mLayout
+               );
+    }
+
+    ListOf(ListOfType::layout* l) {
+        getType()->copy_constructor(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&l
+               );
+    }
+
+    ~ListOf() {
+        getType()->destroy((instance_ptr)&mLayout);
+    }
+
+    ListOf& operator=(const ListOf& other)
+    {
+        getType()->assign(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&other.mLayout
+               );
+        return *this;
+    }
+
+    ListOfType::layout* getLayout() const {
+        return mLayout;
+    }
+
+private:
+    ListOfType::layout* mLayout;
+};
+
+template<class element_type>
+class TypeDetails<ListOf<element_type>> {
+public:
+    static Type* getType() {
+        static Type* t = ListOfType::Make(TypeDetails<element_type>::getType());
+        if (t->bytecount() != bytecount) {
+            throw std::runtime_error("somehow we have the wrong bytecount!");
+        }
+        return t;
+    }
+
+    static const uint64_t bytecount = sizeof(void*);
+};
+
+template<class element_type>
+class TupleOf {
+public:
+    static TupleOfType* getType() {
+        static TupleOfType* t = TupleOfType::Make(TypeDetails<element_type>::getType());
+
+        return t;
+    }
+
+    static Type* getEltType() {
+        static Type* t = getType()->getEltType();
+        return t;
+    }
+
+    static TupleOf<element_type> fromPython(PyObject* p) {
+        TupleOfType::layout* l = nullptr;
+        PyInstance::copyConstructFromPythonInstance(getType(), (instance_ptr)&l, p, true);
+        return (TupleOf<element_type>)l;
+    }
+
+    element_type& operator[](int64_t offset) {
+       return *(element_type*)((uint8_t*)mLayout->data + TypeDetails<element_type>::bytecount * offset);
+    }
+
+    const element_type& operator[](int64_t offset) const {
+       return *(element_type*)((uint8_t*)mLayout->data + TypeDetails<element_type>::bytecount * offset);
+    }
+
+    size_t size() const {
+        return !mLayout ? 0 : sizeof(*mLayout) + TypeDetails<element_type>::bytecount * mLayout->count;
+    }
+
+    size_t count() const {
+        return !mLayout ? 0 : mLayout->count;
+    }
+
+    template<class buf_t>
+    void serialize(buf_t& buffer) {
+        getType()->serialize<buf_t>((instance_ptr)&mLayout, buffer);
+    }
+
+    template<class buf_t>
+    void deserialize(buf_t& buffer) {
+        getType()->deserialize<buf_t>((instance_ptr)&mLayout, buffer);
+    }
+
+    TupleOf(): mLayout(0) {
+        getType()->constructor((instance_ptr)&mLayout);
+    }
+
+    TupleOf(const TupleOf& other)
+    {
+        getType()->copy_constructor(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&other.mLayout
+               );
+    }
+
+    TupleOf(TupleOfType::layout* l) {
+        getType()->copy_constructor(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&l
+               );
+    }
+
+    TupleOf(const std::vector<element_type>& v): mLayout(0) {
+        getType()->constructor((instance_ptr)&mLayout, v.size(),
+            [&](instance_ptr target, int64_t k) {
+                getEltType()->constructor(target);
+                getEltType()->assign(target, (instance_ptr)(&v[k]));
+            }
+        );
+    }
+
+    ~TupleOf() {
+        getType()->destroy((instance_ptr)&mLayout);
+    }
+
+    TupleOf& operator=(const TupleOf& other)
+    {
+        getType()->assign(
+               (instance_ptr)&mLayout,
+               (instance_ptr)&other.mLayout
+               );
+        return *this;
+    }
+
+    TupleOfType::layout* getLayout() const {
+        return mLayout;
+    }
+
+private:
+    TupleOfType::layout* mLayout;
+};
+
+template<class element_type>
+class TypeDetails<TupleOf<element_type>> {
+public:
+    static Type* getType() {
+        static Type* t = TupleOf<element_type>::getType();
+        if (t->bytecount() != bytecount) {
+            throw std::runtime_error("somehow we have the wrong bytecount!");
+        }
+        return t;
+    }
+
+    static const uint64_t bytecount = sizeof(void*);
+};
+
 class String {
     public:
         static StringType* getType() {
@@ -84,16 +307,16 @@ class String {
         int64_t find(const String& sub, int64_t start, int64_t end) { return StringType::find(mLayout, sub.getLayout(), start, end); }
         int64_t find(const String& sub, int64_t start) { return StringType::find(mLayout, sub.getLayout(), start, mLayout ? mLayout->pointcount : 0); }
         int64_t find(const String& sub) { return StringType::find(mLayout, sub.getLayout(), 0, mLayout ? mLayout->pointcount : 0); }
-//        ListOf<String> split(const String& sep, int64_t max = -1) {
-//           ListOf<String> ret;
-//           StringType::split(ret.getType()->getLayout(), mLayout, sep.getLayout(), max);
-//           return ret;
-//        }
-//        ListOf<String> split(int64_t max = -1) {
-//           ListOf<String> ret;
-//           StringType::split_3(ret.getType()->getLayout(), mLayout, max);
-//           return ret;
-//        }
+        ListOf<String> split(const String& sep, int64_t max = -1) {
+           ListOf<String> ret;
+           StringType::split(ret.getLayout(), mLayout, sep.getLayout(), max);
+           return ret;
+        }
+        ListOf<String> split(int64_t max = -1) {
+           ListOf<String> ret;
+           StringType::split_3(ret.getLayout(), mLayout, max);
+           return ret;
+        }
         bool isalpha() { return StringType::isalpha(mLayout); }
         bool isalnum() { return StringType::isalnum(mLayout); }
         bool isdecimal() { return StringType::isdecimal(mLayout); }
@@ -124,206 +347,6 @@ public:
 
     static const uint64_t bytecount = sizeof(void*);
 };
-
-//templates for TupleOf, ListOf, Dict, ConstDict, OneOf
-template<class element_type>
-class ListOf {
-public:
-    static ListOfType* getType() {
-        static ListOfType* t = ListOfType::Make(TypeDetails<element_type>::getType());
-        return t;
-    }
-    static Type* getEltType() {
-        static Type* t = getType()->getEltType();
-        return t;
-    }
-
-    static ListOf<element_type> fromPython(PyObject* p) {
-        ListOfType::layout* l = nullptr;
-        PyInstance::copyConstructFromPythonInstance(getType(), (instance_ptr)&l, p, true);
-        return (ListOf<element_type>)l;
-    }
-
-    element_type& operator[](int64_t offset) {
-       return *(element_type*)((uint8_t*)mLayout->data + TypeDetails<element_type>::bytecount * offset);
-    }
- 
-    const element_type& operator[](int64_t offset) const {
-       return *(element_type*)((uint8_t*)mLayout->data + TypeDetails<element_type>::bytecount * offset);
-    }
-
-    size_t size() const {
-        return !mLayout ? 0 : sizeof(*mLayout) + TypeDetails<element_type>::bytecount * mLayout->count;
-    }
-
-    size_t count() const {
-        return !mLayout ? 0 : mLayout->count;
-    }
-
-    void append(const element_type& e) {
-        getType()->append((instance_ptr)&mLayout, (instance_ptr)&e);
-    }
-
-    template<class buf_t>
-    void serialize(buf_t& buffer) {
-        getType()->serialize<buf_t>((instance_ptr)&mLayout, buffer);
-    }
-
-    template<class buf_t>
-    void deserialize(buf_t& buffer) {
-        getType()->deserialize<buf_t>((instance_ptr)&mLayout, buffer);
-    }
-
-    ListOf(): mLayout(0) {
-        getType()->constructor((instance_ptr)&mLayout);
-    }
-
-    ListOf(const std::vector<element_type>& v): mLayout(0) {
-        getType()->constructor((instance_ptr)&mLayout, v.size(),
-            [&](instance_ptr target, int64_t k) {
-                getEltType()->constructor(target);
-                getEltType()->assign(target, (instance_ptr)(&v[k]));
-            }
-        );
-    }
-
-    ~ListOf() {
-        getType()->destroy((instance_ptr)&mLayout);
-    }
-
-    ListOf(const ListOf& other)
-    {
-        getType()->copy_constructor(
-               (instance_ptr)&mLayout,
-               (instance_ptr)&other.mLayout
-               );
-    }
-
-    ListOf(ListOfType::layout* l) {
-        getType()->copy_constructor(
-               (instance_ptr)&mLayout,
-               (instance_ptr)&l
-               );
-    }
-
-    ListOf& operator=(const ListOf& other)
-    {
-        getType()->assign(
-               (instance_ptr)&mLayout,
-               (instance_ptr)&other.mLayout
-               );
-        return *this;
-    }
-
-    ListOfType::layout* getLayout() const {
-        return mLayout;
-    }
-
-private:
-    ListOfType::layout* mLayout;
-};
-
-template<class element_type>
-class TypeDetails<ListOf<element_type>> {
-public:
-    static Type* getType() {
-        static Type* t = ListOfType::Make(TypeDetails<element_type>::getType());
-        if (t->bytecount() != bytecount) {
-            throw std::runtime_error("somehow we have the wrong bytecount!");
-        }
-        return t;
-    }
-
-    static const uint64_t bytecount = sizeof(void*);
-};
-
-template<class element_type>
-class TupleOf {
-public:
-    static TupleOfType* getType() {
-        static TupleOfType* t = TupleOfType::Make(TypeDetails<element_type>::getType());
-
-        return t;
-    }
-
-    static TupleOf<element_type> fromPython(PyObject* p) {
-        TupleOfType::layout* l = nullptr;
-        PyInstance::copyConstructFromPythonInstance(getType(), (instance_ptr)&l, p, true);
-        return (TupleOf<element_type>)l;
-    }
-
-    element_type& operator[](int64_t offset) {
-       return *(element_type*)((uint8_t*)mLayout->data + TypeDetails<element_type>::bytecount * offset);
-    }
-
-    const element_type& operator[](int64_t offset) const {
-       return *(element_type*)((uint8_t*)mLayout->data + TypeDetails<element_type>::bytecount * offset);
-    }
-
-    size_t size() const {
-        return !mLayout ? 0 : sizeof(*mLayout) + TypeDetails<element_type>::bytecount * mLayout->count;
-    }
-
-    template<class buf_t>
-    void serialize(buf_t& buffer) {
-        getType()->serialize<buf_t>((instance_ptr)&mLayout, buffer);
-    }
-
-    template<class buf_t>
-    void deserialize(buf_t& buffer) {
-        getType()->deserialize<buf_t>((instance_ptr)&mLayout, buffer);
-    }
-
-    TupleOf(): mLayout(0) {
-        getType()->constructor((instance_ptr)&mLayout);
-    }
-
-    ~TupleOf() {
-        getType()->destroy((instance_ptr)&mLayout);
-    }
-
-    TupleOf(const TupleOf& other)
-    {
-        getType()->copy_constructor(
-               (instance_ptr)&mLayout,
-               (instance_ptr)&other.mLayout
-               );
-    }
-
-    TupleOf(TupleOfType::layout* l) {
-        getType()->copy_constructor(
-               (instance_ptr)&mLayout,
-               (instance_ptr)&l
-               );
-    }
-
-    TupleOf& operator=(const TupleOf& other)
-    {
-        getType()->assign(
-               (instance_ptr)&mLayout,
-               (instance_ptr)&other.mLayout
-               );
-        return *this;
-    }
-
-private:
-    TupleOfType::layout* mLayout;
-};
-
-template<class element_type>
-class TypeDetails<TupleOf<element_type>> {
-public:
-    static Type* getType() {
-        static Type* t = TupleOf<element_type>::getType();
-        if (t->bytecount() != bytecount) {
-            throw std::runtime_error("somehow we have the wrong bytecount!");
-        }
-        return t;
-    }
-
-    static const uint64_t bytecount = sizeof(void*);
-};
-
 
 template<class key_type, class value_type>
 class Dict {

--- a/typed_python/DirectTypes.hpp
+++ b/typed_python/DirectTypes.hpp
@@ -475,15 +475,15 @@ public:
         getType()->deserialize<buf_t>((instance_ptr)&mLayout, buffer);
     }
 
-    OneOf() {
+    OneOf<T1, Ts...>() {
         getType()->constructor((instance_ptr)&mLayout);
     }
 
-    ~OneOf() {
+    ~OneOf<T1, Ts...>() {
         getType()->destroy((instance_ptr)&mLayout);
     }
 
-    OneOf(const OneOf& other)
+    OneOf<T1, Ts...>(const OneOf<T1, Ts...>& other)
     {
         getType()->copy_constructor(
                (instance_ptr)&mLayout,
@@ -491,14 +491,14 @@ public:
                );
     }
 
-    OneOf(OneOf<T1, Ts...>::layout* l) {
+    OneOf<T1, Ts...>(OneOf<T1, Ts...>::layout* l) {
         getType()->copy_constructor(
                (instance_ptr)&mLayout,
                (instance_ptr)&l
                );
     }
 
-    OneOf& operator=(const OneOf& other)
+    OneOf<T1, Ts...>& operator=(const OneOf<T1, Ts...>& other)
     {
         getType()->assign(
                (instance_ptr)&mLayout,

--- a/typed_python/DirectTypes.hpp
+++ b/typed_python/DirectTypes.hpp
@@ -618,10 +618,8 @@ public:
 
     template <class T>
     OneOf(const T& o) {
-        //std::cerr << "OneOf constructor " << getType()->name() << "/" << TypeDetails<T>::getType()->name() << std::endl;
         getType()->constructor((instance_ptr)&mLayout);
         static const int k = TypeIndex<T, 0, T1, Ts...>::value;
-        //std::cerr << std::hex << (uint64_t)&mLayout << "  " << k << std::endl;
         mLayout.which = k;
         getType()->getTypes()[k]->copy_constructor((instance_ptr)&mLayout.data, (instance_ptr)&o);
     }

--- a/typed_python/DirectTypes.hpp
+++ b/typed_python/DirectTypes.hpp
@@ -228,110 +228,110 @@ public:
 };
 
 class String {
-    public:
-        static StringType* getType() {
-            static StringType* t = StringType::Make();
-            return t;
-        }
+public:
+    static StringType* getType() {
+        static StringType* t = StringType::Make();
+        return t;
+    }
 
-        String():mLayout(0) {}
+    String():mLayout(0) {}
 
-        explicit String(const char *pc):mLayout(0) {
-            getType()->constructor((instance_ptr)&mLayout, 1, strlen(pc), pc);
-        }
+    explicit String(const char *pc):mLayout(0) {
+        getType()->constructor((instance_ptr)&mLayout, 1, strlen(pc), pc);
+    }
 
-        explicit String(std::string& s):mLayout(0) {
-            getType()->constructor((instance_ptr)&mLayout, 1, s.length(), s.data());
-        }
+    explicit String(std::string& s):mLayout(0) {
+        getType()->constructor((instance_ptr)&mLayout, 1, s.length(), s.data());
+    }
 
-        explicit String(StringType::layout* l):mLayout(0) {
-            getType()->constructor((instance_ptr)&mLayout, l->bytes_per_codepoint, l->pointcount, (const char*)l->data);
-        }
+    explicit String(StringType::layout* l):mLayout(0) {
+        getType()->constructor((instance_ptr)&mLayout, l->bytes_per_codepoint, l->pointcount, (const char*)l->data);
+    }
 
-        ~String() {
-            StringType::destroyStatic((instance_ptr)&mLayout);
-        }
+    ~String() {
+        StringType::destroyStatic((instance_ptr)&mLayout);
+    }
 
-        String(const String& other)
-        {
-            getType()->copy_constructor(
-               (instance_ptr)&mLayout,
-               (instance_ptr)&other.mLayout
-               );
-        }
+    String(const String& other)
+    {
+        getType()->copy_constructor(
+           (instance_ptr)&mLayout,
+           (instance_ptr)&other.mLayout
+           );
+    }
 
-        String& operator=(const String& other)
-        {
-            getType()->assign(
-               (instance_ptr)&mLayout,
-               (instance_ptr)&other.mLayout
-               );
-            return *this;
-        }
+    String& operator=(const String& other)
+    {
+        getType()->assign(
+           (instance_ptr)&mLayout,
+           (instance_ptr)&other.mLayout
+           );
+        return *this;
+    }
 
-        template<class buf_t>
-        void serialize(buf_t& buffer) {
-            getType()->serialize<buf_t>((instance_ptr)&mLayout, buffer);
-        }
+    template<class buf_t>
+    void serialize(buf_t& buffer) {
+        getType()->serialize<buf_t>((instance_ptr)&mLayout, buffer);
+    }
 
-        template<class buf_t>
-        void deserialize(buf_t& buffer) {
-            getType()->deserialize<buf_t>((instance_ptr)&mLayout, buffer);
-        }
+    template<class buf_t>
+    void deserialize(buf_t& buffer) {
+        getType()->deserialize<buf_t>((instance_ptr)&mLayout, buffer);
+    }
 
-        StringType::layout* getLayout() const {
-            return mLayout;
-        }
+    static inline char cmp(const String& left, const String& right) {
+        return StringType::cmpStatic(left.mLayout, right.mLayout);
+    }
+    bool operator==(const String& right) const { return cmp(*this, right) == 0; }
+    bool operator!=(const String& right) const { return cmp(*this, right) != 0; }
+    bool operator<(const String& right) const { return cmp(*this, right) < 0; }
+    bool operator>(const String& right) const { return cmp(*this, right) > 0; }
+    bool operator<=(const String& right) const { return cmp(*this, right) <= 0; }
+    bool operator>=(const String& right) const { return cmp(*this, right) >= 0; }
 
-        static inline char cmp(const String& left, const String& right) {
-            return StringType::cmpStatic(left.mLayout, right.mLayout);
-        }
-        bool operator==(const String& right) { return cmp(*this, right) == 0; }
-        bool operator!=(const String& right) { return cmp(*this, right) != 0; }
-        bool operator<(const String& right) { return cmp(*this, right) < 0; }
-        bool operator>(const String& right) { return cmp(*this, right) > 0; }
-        bool operator<=(const String& right) { return cmp(*this, right) <= 0; }
-        bool operator>=(const String& right) { return cmp(*this, right) >= 0; }
+    static String concatenate(const String& left, const String& right) {
+        return String(StringType::concatenate(left.getLayout(), right.getLayout()));
+    }
+    String operator+(const String& right) {
+        return String(StringType::concatenate(mLayout, right.getLayout()));
+    }
+    String& operator+=(const String& right) {
+        return *this = String(StringType::concatenate(mLayout, right.getLayout()));
+    }
+    String upper() const { return String(StringType::upper(mLayout)); }
+    String lower() const { return String(StringType::lower(mLayout)); }
+    int64_t find(const String& sub, int64_t start, int64_t end) const { return StringType::find(mLayout, sub.getLayout(), start, end); }
+    int64_t find(const String& sub, int64_t start) const { return StringType::find(mLayout, sub.getLayout(), start, mLayout ? mLayout->pointcount : 0); }
+    int64_t find(const String& sub) const { return StringType::find(mLayout, sub.getLayout(), 0, mLayout ? mLayout->pointcount : 0); }
+    ListOf<String> split(const String& sep, int64_t max = -1) const {
+       ListOf<String> ret;
+       StringType::split(ret.getLayout(), mLayout, sep.getLayout(), max);
+       return ret;
+    }
+    ListOf<String> split(int64_t max = -1) {
+       ListOf<String> ret;
+       StringType::split_3(ret.getLayout(), mLayout, max);
+       return ret;
+    }
+    bool isalpha() const { return StringType::isalpha(mLayout); }
+    bool isalnum() const { return StringType::isalnum(mLayout); }
+    bool isdecimal() const { return StringType::isdecimal(mLayout); }
+    bool isdigit() const { return StringType::isdigit(mLayout); }
+    bool islower() const { return StringType::islower(mLayout); }
+    bool isnumeric() const { return StringType::isnumeric(mLayout); }
+    bool isprintable() const { return StringType::isprintable(mLayout); }
+    bool isspace() const { return StringType::isspace(mLayout); }
+    bool istitle() const { return StringType::istitle(mLayout); }
+    bool isupper() const { return StringType::isupper(mLayout); }
 
-        static String concatenate(const String& left, const String& right) {
-            return String(StringType::concatenate(left.getLayout(), right.getLayout()));
-        }
-        String operator+(const String& right) {
-            return String(StringType::concatenate(mLayout, right.getLayout()));
-        }
-        String& operator+=(const String& right) {
-            return *this = String(StringType::concatenate(mLayout, right.getLayout()));
-        }
-        String upper() { return String(StringType::upper(mLayout)); }
-        String lower() { return String(StringType::lower(mLayout)); }
-        int64_t find(const String& sub, int64_t start, int64_t end) { return StringType::find(mLayout, sub.getLayout(), start, end); }
-        int64_t find(const String& sub, int64_t start) { return StringType::find(mLayout, sub.getLayout(), start, mLayout ? mLayout->pointcount : 0); }
-        int64_t find(const String& sub) { return StringType::find(mLayout, sub.getLayout(), 0, mLayout ? mLayout->pointcount : 0); }
-        ListOf<String> split(const String& sep, int64_t max = -1) {
-           ListOf<String> ret;
-           StringType::split(ret.getLayout(), mLayout, sep.getLayout(), max);
-           return ret;
-        }
-        ListOf<String> split(int64_t max = -1) {
-           ListOf<String> ret;
-           StringType::split_3(ret.getLayout(), mLayout, max);
-           return ret;
-        }
-        bool isalpha() { return StringType::isalpha(mLayout); }
-        bool isalnum() { return StringType::isalnum(mLayout); }
-        bool isdecimal() { return StringType::isdecimal(mLayout); }
-        bool isdigit() { return StringType::isdigit(mLayout); }
-        bool islower() { return StringType::islower(mLayout); }
-        bool isnumeric() { return StringType::isnumeric(mLayout); }
-        bool isprintable() { return StringType::isprintable(mLayout); }
-        bool isspace() { return StringType::isspace(mLayout); }
-        bool istitle() { return StringType::istitle(mLayout); }
-        bool isupper() { return StringType::isupper(mLayout); }
+    String substr(int64_t start, int64_t stop) const { return String(StringType::getsubstr(mLayout, start, stop)); }
 
-        String substr(int64_t start, int64_t stop) { return String(StringType::getsubstr(mLayout, start, stop)); }
+    StringType::layout* getLayout() const {
+        return mLayout;
+    }
 
-    private:
-        StringType::layout* mLayout;
+private:
+    StringType::layout* mLayout;
 };
 
 template<>
@@ -411,8 +411,26 @@ public:
                );
         return *this;
     }
-    const value_type lookupValueByKey(key_type k) {
-        return *(value_type*)(getType()->lookupValueByKey((instance_ptr)&mLayout, (instance_ptr)&k));
+
+    void insertKeyValue(const key_type& k, const value_type& v) {
+        value_type *pv = (value_type*)getType()->lookupValueByKey((instance_ptr)&mLayout, (instance_ptr)&k);
+        if (pv) {
+            TypeDetails<value_type>::getType()->assign((instance_ptr)pv,(instance_ptr)&v);
+        } else {
+            pv = (value_type*)getType()->insertKey((instance_ptr)&mLayout, (instance_ptr)&k);
+            TypeDetails<value_type>::getType()->copy_constructor((instance_ptr)pv, (instance_ptr)&v);
+        }
+    }
+    const value_type* lookupValueByKey(const key_type&  k) const {
+        return (value_type*)(getType()->lookupValueByKey((instance_ptr)&mLayout, (instance_ptr)&k));
+    }
+
+    bool deleteKey(const key_type& k) {
+        return getType()->deleteKey((instance_ptr)&mLayout, (instance_ptr)&k);
+    }
+
+    DictType::layout* getLayout() const {
+        return mLayout;
     }
 
 private:
@@ -496,8 +514,13 @@ public:
                );
         return *this;
     }
-    const value_type lookupValueByKey(key_type k) {
-        return *(value_type*)(getType()->lookupValueByKey((instance_ptr)&mLayout, (instance_ptr)&k));
+
+    const value_type* lookupValueByKey(const key_type&  k) const {
+        return (value_type*)(getType()->lookupValueByKey((instance_ptr)&mLayout, (instance_ptr)&k));
+    }
+
+    ConstDictType::layout* getLayout() const {
+        return mLayout;
     }
 
 private:
@@ -518,16 +541,18 @@ public:
     static const uint64_t bytecount = sizeof(void*);
 };
 
-template<class... Ts>
-class OneOf;
+template<int k, class... Ts>
+class OneOfEx;
 
-template<class T1, class... Ts>
-class OneOf<T1, Ts...> {
+// k is the 0-based index of type T1, assuming we started with OneOfEx<0, ...>
+// OneOf<...> is defined to be OneOfEx<0, ...>
+template<int k, class T1, class... Ts>
+class OneOfEx<k, T1, Ts...> : OneOfEx<k+1, Ts...> {
 public:
-    static const size_t m_datasize = std::max(TypeDetails<T1>::bytecount, OneOf<Ts...>::m_datasize);
-    class layout {
+    static const size_t m_datasize = std::max(TypeDetails<T1>::bytecount, OneOfEx<k, Ts...>::m_datasize);
+    struct layout {
         uint8_t which;
-        uint8_t data[OneOf<T1, Ts...>::m_datasize];
+        uint8_t data[OneOfEx<k, T1, Ts...>::m_datasize];
     };
 private:
     layout mLayout;
@@ -538,10 +563,10 @@ public:
         return t;
     }
 
-    static OneOf<T1, Ts...> fromPython(PyObject* p) {
-        OneOf<T1, Ts...>::layout* l = nullptr;
+    static OneOfEx<k, T1, Ts...> fromPython(PyObject* p) {
+        OneOfEx<k, T1, Ts...>::layout* l = nullptr;
         PyInstance::copyConstructFromPythonInstance(getType(), (instance_ptr)&l, p, true);
-        return (OneOf<T1, Ts...>)l;
+        return (OneOfEx<k, T1, Ts...>)l;
     }
 
     std::pair<Type*, instance_ptr> unwrap() {
@@ -562,15 +587,30 @@ public:
         getType()->deserialize<buf_t>((instance_ptr)&mLayout, buffer);
     }
 
-    OneOf<T1, Ts...>() {
+    OneOfEx(const T1& o) {
+        //std::cerr << "OneOf constructor " << TypeDetails<T1>::getType()->name() << std::endl;
         getType()->constructor((instance_ptr)&mLayout);
+        const std::vector<Type*>& types = getType()->getTypes();
+        Type* typ = types[k];
+        if (typ == TypeDetails<T1>::getType()) {
+            mLayout.which = k;
+            typ->copy_constructor((instance_ptr)&mLayout.data, (instance_ptr)&o);
+        }
     }
 
-    ~OneOf<T1, Ts...>() {
-        getType()->destroy((instance_ptr)&mLayout);
+    OneOfEx() {
+        // We want only the first constructor, not the constructors from parent (fewer template parameters) classes
+        if (k==0)
+            getType()->constructor((instance_ptr)&mLayout);
     }
 
-    OneOf<T1, Ts...>(const OneOf<T1, Ts...>& other)
+    ~OneOfEx() {
+        // We want only the first destructor, not the destructors from parent (fewer template parameters) classes
+        if (k==0)
+            getType()->destroy((instance_ptr)&mLayout);
+    }
+
+    OneOfEx(const OneOfEx<k, T1, Ts...>& other)
     {
         getType()->copy_constructor(
                (instance_ptr)&mLayout,
@@ -578,14 +618,14 @@ public:
                );
     }
 
-    OneOf<T1, Ts...>(OneOf<T1, Ts...>::layout* l) {
+    OneOfEx(OneOfEx<k, T1, Ts...>::layout* l) {
         getType()->copy_constructor(
                (instance_ptr)&mLayout,
                (instance_ptr)&l
                );
     }
 
-    OneOf<T1, Ts...>& operator=(const OneOf<T1, Ts...>& other)
+    OneOfEx<k, T1, Ts...>& operator=(const OneOfEx<k, T1, Ts...>& other)
     {
         getType()->assign(
                (instance_ptr)&mLayout,
@@ -595,22 +635,25 @@ public:
     }
 };
 
-template <>
-class OneOf<> {
+template <int k>
+class OneOfEx<k> {
 public:
     static const size_t m_datasize = 0;
 };
 
-template<class... Ts>
-class TypeDetails<OneOf<Ts...>> {
+template<int k, class... Ts>
+class TypeDetails<OneOfEx<k, Ts...>> {
 public:
     static Type* getType() {
-        static Type* t = OneOf<Ts...>::getType();
+        static Type* t = OneOfEx<k, Ts...>::getType();
         if (t->bytecount() != bytecount) {
             throw std::runtime_error("somehow we have the wrong bytecount!");
         }
         return t;
     }
 
-    static const uint64_t bytecount = 1 + OneOf<Ts...>::m_datasize;
+    static const uint64_t bytecount = 1 + OneOfEx<k, Ts...>::m_datasize;
 };
+
+template<class... Ts>
+using OneOf = OneOfEx<0, Ts...>;

--- a/typed_python/DirectTypesTest.cpp
+++ b/typed_python/DirectTypesTest.cpp
@@ -1,10 +1,13 @@
 #include "DirectTypes.hpp"
 #include "DirectTypesTest.hpp"
 
-#define my_assert(cond) if (!(cond)) { std::cerr << " failure at " << __FILE__ << " line " << std::dec << __LINE__ << std::endl; return 1; }
+#define my_assert(cond) if (!(cond)) { std::cerr << "  failure: " << #cond << std::endl << "  " << __FILE__ << " line " << std::dec << __LINE__ << std::endl; return 1; }
+#define test_fn_header() std::cerr << " Start " << __FUNCTION__ << "()" << std::endl;
+
+void errlog(std::string a) { std::cerr << a << std::endl; }
 
 int test_string() {
-    std::cerr << "start " << __FUNCTION__ << std::endl;
+    test_fn_header()
     String s1("abc");
     StringType::layout* l = s1.getLayout();
     my_assert(l->pointcount == 3)
@@ -83,11 +86,28 @@ int test_string() {
 
     my_assert(String("a") > String("A"))
     my_assert(String("abc") < String("abcd"))
+
+    String s5("one two three four");
+    ListOf<String> parts = s5.split();
+    my_assert(parts.count() == 4)
+    my_assert(parts[0] == String("one"))
+    my_assert(parts[1] == String("two"))
+    my_assert(parts[2] == String("three"))
+    my_assert(parts[3] == String("four"))
+    parts = s5.split(String("t"));
+    my_assert(parts.count() == 3)
+    my_assert(parts[0] == String("one "))
+    my_assert(parts[1] == String("wo "))
+    my_assert(parts[2] == String("hree four"))
+    parts = s5.split(2);
+    my_assert(parts.count() == 3)
+    parts = s5.split(String("t"), 1);
+    my_assert(parts.count() == 2)
     return 0;
 }
 
 int test_list_of() {
-    std::cerr << "start " << __FUNCTION__ << std::endl;
+    test_fn_header()
     ListOf<int64_t> list1;
     my_assert(list1.count() == 0)
     my_assert(list1.getLayout()->refcount == 1)
@@ -99,6 +119,8 @@ int test_list_of() {
     {
         ListOf<int64_t> list3 = list2;
         my_assert(list2.getLayout()->refcount == 2)
+        ListOf<int64_t> list4(list3);
+        my_assert(list2.getLayout()->refcount == 3)
     }
     my_assert(list2.getLayout()->refcount == 1)
     my_assert(list2[2] == 7)
@@ -107,11 +129,31 @@ int test_list_of() {
     return 0;
 }
 
+int test_tuple_of() {
+    test_fn_header()
+    TupleOf<int64_t> t1;
+    my_assert(t1.count() == 0)
+    TupleOf<int64_t> t2({10, 12, 14, 16});
+    my_assert(t2.getLayout()->refcount == 1)
+    my_assert(t2.count() == 4)
+    my_assert(t2.getLayout()->refcount == 1)
+    {
+        TupleOf<int64_t> t3 = t2;
+        my_assert(t2.getLayout()->refcount == 2)
+        TupleOf<int64_t> t4(t3);
+        my_assert(t2.getLayout()->refcount == 3)
+    }
+    my_assert(t2.getLayout()->refcount == 1)
+    my_assert(t2[2] == 14)
+    return 0;
+}
+
 int direct_cpp_tests() {
     int ret = 0;
-    std::cerr << "start " << __FUNCTION__ << std::endl;
+    std::cerr << "Start " << __FUNCTION__ << "()" << std::endl;
     ret += test_string();
     ret += test_list_of();
+    ret += test_tuple_of();
 
     std::cerr << ret << " test" << (ret == 1 ? "" : "s") << " failed" << std::endl;
 

--- a/typed_python/DirectTypesTest.cpp
+++ b/typed_python/DirectTypesTest.cpp
@@ -126,6 +126,12 @@ int test_list_of() {
     my_assert(list2[2] == 7)
     list2[2] = 42;
     my_assert(list2[2] == 42)
+    ListOf<String> list4({String("ab"), String("cd")});
+    my_assert(list4.count() == 2)
+    my_assert(list4[0] == String("ab"))
+    my_assert(list4[1] == String("cd"))
+    list4[1] = String("replace");
+    my_assert(list4[1] == String("replace"))
     return 0;
 }
 
@@ -148,12 +154,51 @@ int test_tuple_of() {
     return 0;
 }
 
+int test_dict() {
+    test_fn_header()
+    Dict<bool, int64_t> d1;
+    d1.insertKeyValue(false, 13);
+    d1.insertKeyValue(true, 17);
+    const int64_t *pv = d1.lookupValueByKey(false);
+    my_assert(pv);
+    my_assert(*pv == 13);
+    pv = d1.lookupValueByKey(true);
+    my_assert(pv);
+    my_assert(*pv == 17);
+    my_assert(d1.getLayout()->refcount == 1)
+    bool deleted = d1.deleteKey(true);
+    my_assert(deleted)
+    pv = d1.lookupValueByKey(true);
+    my_assert(pv == 0)
+    {
+        Dict<bool, int64_t>d2 = d1;
+        Dict<bool, int64_t>d3 = d2;
+        my_assert(d1.getLayout()->refcount == 3)
+    }
+    my_assert(d1.getLayout()->refcount == 1)
+    Dict<String, String> d4;
+    d4.insertKeyValue(String("first"), String("1st"));
+    d4.insertKeyValue(String("second"), String("2nd"));
+    d4.insertKeyValue(String("third"), String("3rd"));
+    const String *ps = d4.lookupValueByKey(String("second"));
+    my_assert(ps);
+    my_assert(*ps == String("2nd"));
+    return 0;
+}
+
+int test_one_of() {
+    test_fn_header()
+    OneOf<bool, int> o1;
+    return 0;
+}
+
 int direct_cpp_tests() {
     int ret = 0;
     std::cerr << "Start " << __FUNCTION__ << "()" << std::endl;
     ret += test_string();
     ret += test_list_of();
     ret += test_tuple_of();
+    ret += test_dict();
 
     std::cerr << ret << " test" << (ret == 1 ? "" : "s") << " failed" << std::endl;
 

--- a/typed_python/DirectTypesTest.cpp
+++ b/typed_python/DirectTypesTest.cpp
@@ -1,0 +1,97 @@
+#include "DirectTypes.hpp"
+#include "DirectTypesTest.hpp"
+
+#define my_assert(cond) if (!(cond)) { std::cerr << " failure at " << __FILE__ << " line " << std::dec << __LINE__ << std::endl; return 1; }
+
+int test_string() {
+    std::cerr << "start " << __FUNCTION__ << std::endl;
+    String s1("abc");
+    StringType::layout* l = s1.getLayout();
+    my_assert(l->pointcount == 3)
+    my_assert(l->bytes_per_codepoint == 1)
+    std::string s2a("abc");
+    String s2(s2a);
+    my_assert(s1 == s2)
+    {
+        String s3(s2);
+        my_assert(s3 == s2)
+        String s4 = s2;
+        my_assert(s4 == s2)
+        my_assert(s1.getLayout()->refcount == 1)
+        my_assert(s2.getLayout()->refcount == 3)
+        my_assert(s3.getLayout()->refcount == 3)
+        my_assert(s4.getLayout()->refcount == 3)
+    }
+    my_assert(s1.getLayout()->refcount == 1)
+    my_assert(s2.getLayout()->refcount == 1)
+    s2 = s1.upper();
+    my_assert(s2 == String("ABC"))
+    my_assert(s2.getLayout()->refcount == 1)
+    s2 = s2.lower();
+    my_assert(s2 == String("abc"))
+    my_assert(s2.getLayout()->refcount == 1)
+    String s3("abcxy");
+    my_assert(s3.getLayout()->pointcount == 5)
+    my_assert(s3.find(String("cx")) == 2)
+    my_assert(s3.substr(1,4) == String("bcx"))
+    String a1("DEF");
+    String a2("ghij");
+    String a3("K");
+    String a4("mno");
+    String s("blank");
+    s = a1 + a2;
+    my_assert(s == String("DEFghij"))
+    my_assert(s.getLayout()->refcount == 1)
+    s = a1 + a2 + a3;
+    my_assert(s == String("DEFghijK"))
+    my_assert(s.getLayout()->refcount == 1)
+    s = a1 + a2 + a3 + a4;
+    my_assert(s == String("DEFghijKmno"))
+    my_assert(s.getLayout()->refcount == 1)
+    String s4("test");
+    s4 = s4;
+    my_assert(s4.getLayout()->refcount == 1)
+    s4 = String("12345");
+    my_assert(s4.getLayout()->refcount == 1)
+    s4 = String("aaaaaaaaaaaaaaaa");
+    my_assert(s4.getLayout()->refcount == 1)
+    s1 = String("aBc");
+    s2 = String("123X56");
+    s2 = String("123");
+    s2 = String("xyz");
+    s2 = String("ASD");
+    my_assert(String("aBc").isalpha())
+    my_assert(!String("a3Bc").isalpha())
+    my_assert(String("a3Bc").isalnum())
+    my_assert(!String("aB%c").isalnum())
+    my_assert(String("43234").isdecimal())
+    my_assert(!String("43r234").isdecimal())
+    my_assert(String("43234").isdigit())
+    my_assert(!String("43r234").isdigit())
+    my_assert(String("abc 2").islower())
+    my_assert(!String("4rL34").islower())
+    my_assert(String("43234").isnumeric())
+    my_assert(!String("43r234").isnumeric())
+    my_assert(String("efg43234").isprintable())
+    my_assert(!String("\x01").isprintable())
+    my_assert(String("\n \r").isspace())
+    my_assert(!String("\n A\r").isspace())
+    my_assert(String("One Two").istitle())
+    my_assert(!String("OnE Two").istitle())
+    my_assert(String("OET").isupper())
+    my_assert(!String("OnE Two").isupper())
+
+    my_assert(String("a") > String("A"))
+    my_assert(String("abc") < String("abcd"))
+    return 0;
+}
+
+int direct_cpp_tests() {
+    int ret = 0;
+    std::cerr << "start " << __FUNCTION__ << std::endl;
+    ret += test_string();
+
+    std::cerr << ret << " test" << (ret == 1 ? "" : "s") << " failed" << std::endl;
+
+    return ret > 0;
+}

--- a/typed_python/DirectTypesTest.cpp
+++ b/typed_python/DirectTypesTest.cpp
@@ -226,13 +226,23 @@ int test_one_of() {
 
     o3 = false;
     my_assert(o3.getLayout()->which == 0)
+    my_assert(!o3.getValue(s));
+    my_assert(!o3.getValue(t));
     my_assert(o3.getValue(b))
     my_assert(b == false)
 
     o3 = String("yes");
     my_assert(o3.getLayout()->which == 1)
+    my_assert(!o3.getValue(b))
+    my_assert(!o3.getValue(t));
     my_assert(o3.getValue(s));
     my_assert(s == String("yes"))
+
+    // fails:
+//    OneOf<OneOf<bool, String>, OneOf<int32_t, String>> o4;
+//    o4 = String("a");
+//    o4 = (int32_t)9;
+//    o4 = true;
     return 0;
 }
 

--- a/typed_python/DirectTypesTest.cpp
+++ b/typed_python/DirectTypesTest.cpp
@@ -86,10 +86,32 @@ int test_string() {
     return 0;
 }
 
+int test_list_of() {
+    std::cerr << "start " << __FUNCTION__ << std::endl;
+    ListOf<int64_t> list1;
+    my_assert(list1.count() == 0)
+    my_assert(list1.getLayout()->refcount == 1)
+    ListOf<int64_t> list2({9, 8, 7});
+    my_assert(list2.count() == 3)
+    list2.append(6);
+    my_assert(list2.count() == 4)
+    my_assert(list2.getLayout()->refcount == 1)
+    {
+        ListOf<int64_t> list3 = list2;
+        my_assert(list2.getLayout()->refcount == 2)
+    }
+    my_assert(list2.getLayout()->refcount == 1)
+    my_assert(list2[2] == 7)
+    list2[2] = 42;
+    my_assert(list2[2] == 42)
+    return 0;
+}
+
 int direct_cpp_tests() {
     int ret = 0;
     std::cerr << "start " << __FUNCTION__ << std::endl;
     ret += test_string();
+    ret += test_list_of();
 
     std::cerr << ret << " test" << (ret == 1 ? "" : "s") << " failed" << std::endl;
 

--- a/typed_python/DirectTypesTest.cpp
+++ b/typed_python/DirectTypesTest.cpp
@@ -8,11 +8,13 @@ void errlog(std::string a) { std::cerr << a << std::endl; }
 
 int test_string() {
     test_fn_header()
+
     String s1("abc");
     StringType::layout* l = s1.getLayout();
     my_assert(l->pointcount == 3)
     my_assert(l->bytes_per_codepoint == 1)
     std::string s2a("abc");
+
     String s2(s2a);
     my_assert(s1 == s2)
     {
@@ -27,16 +29,19 @@ int test_string() {
     }
     my_assert(s1.getLayout()->refcount == 1)
     my_assert(s2.getLayout()->refcount == 1)
+
     s2 = s1.upper();
     my_assert(s2 == String("ABC"))
     my_assert(s2.getLayout()->refcount == 1)
     s2 = s2.lower();
     my_assert(s2 == String("abc"))
     my_assert(s2.getLayout()->refcount == 1)
+
     String s3("abcxy");
     my_assert(s3.getLayout()->pointcount == 5)
     my_assert(s3.find(String("cx")) == 2)
     my_assert(s3.substr(1,4) == String("bcx"))
+
     String a1("DEF");
     String a2("ghij");
     String a3("K");
@@ -51,6 +56,7 @@ int test_string() {
     s = a1 + a2 + a3 + a4;
     my_assert(s == String("DEFghijKmno"))
     my_assert(s.getLayout()->refcount == 1)
+
     String s4("test");
     s4 = s4;
     my_assert(s4.getLayout()->refcount == 1)
@@ -63,6 +69,7 @@ int test_string() {
     s2 = String("123");
     s2 = String("xyz");
     s2 = String("ASD");
+
     my_assert(String("aBc").isalpha())
     my_assert(!String("a3Bc").isalpha())
     my_assert(String("a3Bc").isalnum())
@@ -108,14 +115,17 @@ int test_string() {
 
 int test_list_of() {
     test_fn_header()
+
     ListOf<int64_t> list1;
     my_assert(list1.count() == 0)
     my_assert(list1.getLayout()->refcount == 1)
+
     ListOf<int64_t> list2({9, 8, 7});
     my_assert(list2.count() == 3)
     list2.append(6);
     my_assert(list2.count() == 4)
     my_assert(list2.getLayout()->refcount == 1)
+
     {
         ListOf<int64_t> list3 = list2;
         my_assert(list2.getLayout()->refcount == 2)
@@ -126,6 +136,7 @@ int test_list_of() {
     my_assert(list2[2] == 7)
     list2[2] = 42;
     my_assert(list2[2] == 42)
+
     ListOf<String> list4({String("ab"), String("cd")});
     my_assert(list4.count() == 2)
     my_assert(list4[0] == String("ab"))
@@ -137,12 +148,15 @@ int test_list_of() {
 
 int test_tuple_of() {
     test_fn_header()
+
     TupleOf<int64_t> t1;
     my_assert(t1.count() == 0)
+
     TupleOf<int64_t> t2({10, 12, 14, 16});
     my_assert(t2.getLayout()->refcount == 1)
     my_assert(t2.count() == 4)
     my_assert(t2.getLayout()->refcount == 1)
+
     {
         TupleOf<int64_t> t3 = t2;
         my_assert(t2.getLayout()->refcount == 2)
@@ -156,6 +170,7 @@ int test_tuple_of() {
 
 int test_dict() {
     test_fn_header()
+
     Dict<bool, int64_t> d1;
     d1.insertKeyValue(false, 13);
     d1.insertKeyValue(true, 17);
@@ -170,12 +185,14 @@ int test_dict() {
     my_assert(deleted)
     pv = d1.lookupValueByKey(true);
     my_assert(pv == 0)
+
     {
         Dict<bool, int64_t>d2 = d1;
         Dict<bool, int64_t>d3 = d2;
         my_assert(d1.getLayout()->refcount == 3)
     }
     my_assert(d1.getLayout()->refcount == 1)
+
     Dict<String, String> d4;
     d4.insertKeyValue(String("first"), String("1st"));
     d4.insertKeyValue(String("second"), String("2nd"));
@@ -188,7 +205,34 @@ int test_dict() {
 
 int test_one_of() {
     test_fn_header()
-    OneOf<bool, int> o1;
+
+    OneOf<bool, String> o1(true);
+    my_assert(o1.getLayout()->which == 0)
+
+    OneOf<bool, String> o2(String("true"));
+    my_assert(o2.getLayout()->which == 1)
+
+    OneOf<bool, String, TupleOf<int>> o3;
+    bool b;
+    String s;
+    TupleOf<int> t;
+    o3 = TupleOf<int>({9,8,7});
+    my_assert(o3.getLayout()->which == 2)
+    my_assert(!o3.getValue(b));
+    my_assert(!o3.getValue(s));
+    my_assert(o3.getValue(t));
+    my_assert(t.count() == 3);
+    my_assert(t[0] == 9 && t[1] == 8 && t[2] == 7);
+
+    o3 = false;
+    my_assert(o3.getLayout()->which == 0)
+    my_assert(o3.getValue(b))
+    my_assert(b == false)
+
+    o3 = String("yes");
+    my_assert(o3.getLayout()->which == 1)
+    my_assert(o3.getValue(s));
+    my_assert(s == String("yes"))
     return 0;
 }
 
@@ -199,6 +243,7 @@ int direct_cpp_tests() {
     ret += test_list_of();
     ret += test_tuple_of();
     ret += test_dict();
+    ret += test_one_of();
 
     std::cerr << ret << " test" << (ret == 1 ? "" : "s") << " failed" << std::endl;
 

--- a/typed_python/DirectTypesTest.hpp
+++ b/typed_python/DirectTypesTest.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+int direct_cpp_tests();
+

--- a/typed_python/GeneratedTypes.hpp
+++ b/typed_python/GeneratedTypes.hpp
@@ -1,4 +1,361 @@
-// "NamedTupleTwoStrings"
+// Generated Alternative A
+//    A=
+//   Sub1=(b=int64_t, c=int64_t)
+//   Sub2=(d=String, e=String)
+
+class A_Sub1;
+class A_Sub2;
+
+class A {
+public:
+    struct e {
+        enum kind { Sub1=0, Sub2=1 };
+    };
+
+    static NamedTuple* Sub1_Type;
+    typedef int64_t Sub1_b_type;
+    typedef int64_t Sub1_c_type;
+    static const int Sub1_size1 = sizeof(Sub1_b_type);
+    static const int Sub1_size2 = sizeof(Sub1_c_type);
+    static NamedTuple* Sub2_Type;
+    typedef String Sub2_d_type;
+    typedef String Sub2_e_type;
+    static const int Sub2_size1 = sizeof(Sub2_d_type);
+    static const int Sub2_size2 = sizeof(Sub2_e_type);
+
+    static Alternative* getType() {
+        static Alternative* t = Alternative::Make("A", {
+            {"Sub1", Sub1_Type},
+            {"Sub2", Sub2_Type}
+        }, {});
+        return t;
+    }
+    ~A();
+    A(); // only if the whole alternative is default initializable
+    A(const A& in);
+    A& operator=(const A& other);
+
+    static A Sub1(Sub1_b_type b, Sub1_c_type c);
+    static A Sub2(Sub2_d_type d, Sub2_e_type e);
+
+    e::kind which() const { return (e::kind)mLayout->which; }
+
+    template <class F>
+    auto check(const F& f) {
+        if (isSub1()) { return f(*(A_Sub1*)this); }
+        if (isSub2()) { return f(*(A_Sub2*)this); }
+    }
+
+    bool isSub1() const { return which() == e::Sub1; }
+    bool isSub2() const { return which() == e::Sub2; }
+
+    // Accessors for elements of all subtypes here
+    // But account for element name overlap and type differences...
+    // const Sub1_b_type& b() const {}
+    // const Sub1_c_type& c() const {}
+    // const Sub2_d_type& d() const {}
+    // const Sub2_e_type& e() const {}
+    Alternative::layout* getLayout() const { return mLayout; }
+private:
+    Alternative::layout *mLayout;
+};
+
+NamedTuple* A::Sub1_Type = NamedTuple::Make(
+    {TypeDetails<Sub1_b_type>::getType(), TypeDetails<Sub1_c_type>::getType()},
+    {"b", "c"}
+);
+NamedTuple* A::Sub2_Type = NamedTuple::Make(
+    {TypeDetails<Sub2_d_type>::getType(), TypeDetails<Sub2_e_type>::getType()},
+    {"d", "e"}
+);
+
+class A_Sub1 : public A {
+public:
+    static ConcreteAlternative* getType() {
+        static ConcreteAlternative* t = ConcreteAlternative::Make(A::getType(), e::Sub1);
+        return t;
+    }
+    static Alternative* getAlternative() { return A::getType(); }
+
+    A_Sub1() { 
+        getType()->constructor(
+            (instance_ptr)getLayout(),
+            [](instance_ptr p) {Sub1_Type->constructor(p);});
+    }
+    A_Sub1(Sub1_b_type b1, Sub1_c_type c1) {
+        A_Sub1(); 
+        b() = b1;
+        c() = c1;
+     }
+    A_Sub1(const A_Sub1& other) {
+        getType()->copy_constructor((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+    }
+    A_Sub1& operator=(const A_Sub1& other) {
+         getType()->assign((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+    }
+    ~A_Sub1() {
+        getType()->destroy((instance_ptr)getLayout());
+    }
+
+    Sub1_b_type& b() const { return *(Sub1_b_type*)(getLayout()->data); }
+    Sub1_c_type& c() const { return *(Sub1_c_type*)(getLayout()->data + Sub1_size1); }
+};
+
+class A_Sub2 : public A {
+public:
+    static ConcreteAlternative* getType() {
+        static ConcreteAlternative* t = ConcreteAlternative::Make(A::getType(), e::Sub2);
+        return t;
+    }
+    static Alternative* getAlternative() { return A::getType(); }
+
+    A_Sub2() { 
+        getType()->constructor(
+            (instance_ptr)getLayout(),
+            [](instance_ptr p) {Sub2_Type->constructor(p);});
+    }
+    A_Sub2(Sub2_d_type d1, Sub2_e_type e1) {
+        A_Sub2(); 
+        d() = d1;
+        e() = e1;
+     }
+    A_Sub2(const A_Sub2& other) {
+        getType()->copy_constructor((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+    }
+    A_Sub2& operator=(const A_Sub2& other) {
+         getType()->assign((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+    }
+    ~A_Sub2() {
+        getType()->destroy((instance_ptr)getLayout());
+    }
+
+    Sub2_d_type& d() const { return *(Sub2_d_type*)(getLayout()->data); }
+    Sub2_e_type& e() const { return *(Sub2_e_type*)(getLayout()->data + Sub2_size1); }
+};
+
+template <>
+class TypeDetails<A> {
+public:
+    static Type* getType() {
+        static Type* t = A::getType();
+        if (t->bytecount() != bytecount) {
+            throw std::runtime_error("somehow we have the wrong bytecount!");
+        }
+        return t;
+    }
+    static const uint64_t bytecount = sizeof(void*);
+};
+
+class Bexpress;
+
+template <>
+class TypeDetails<Bexpress*> {
+public:
+    static Type* getType() {
+        static Type* t = PointerTo::Make(Int64::Make());  // forward types are not actually constructed
+        return t;
+    }
+    static const uint64_t bytecount = sizeof(void*);
+};
+
+// Generated Alternative Bexpress
+//    Bexpress=
+//   BinOp=(left=Bexpress*, op=String, right=Bexpress*)
+//   UnaryOp=(op=String, right=Bexpress*)
+//   Leaf=(value=bool)
+
+class Bexpress_BinOp;
+class Bexpress_UnaryOp;
+class Bexpress_Leaf;
+
+class Bexpress {
+public:
+    struct e {
+        enum kind { BinOp=0, UnaryOp=1, Leaf=2 };
+    };
+
+    static NamedTuple* BinOp_Type;
+    typedef Bexpress* BinOp_left_type;
+    typedef String BinOp_op_type;
+    typedef Bexpress* BinOp_right_type;
+    static const int BinOp_size1 = sizeof(BinOp_left_type);
+    static const int BinOp_size2 = sizeof(BinOp_op_type);
+    static const int BinOp_size3 = sizeof(BinOp_right_type);
+    static NamedTuple* UnaryOp_Type;
+    typedef String UnaryOp_op_type;
+    typedef Bexpress* UnaryOp_right_type;
+    static const int UnaryOp_size1 = sizeof(UnaryOp_op_type);
+    static const int UnaryOp_size2 = sizeof(UnaryOp_right_type);
+    static NamedTuple* Leaf_Type;
+    typedef bool Leaf_value_type;
+    static const int Leaf_size1 = sizeof(Leaf_value_type);
+
+    static Alternative* getType() {
+        static Alternative* t = Alternative::Make("Bexpress", {
+            {"BinOp", BinOp_Type},
+            {"UnaryOp", UnaryOp_Type},
+            {"Leaf", Leaf_Type}
+        }, {});
+        return t;
+    }
+    ~Bexpress();
+    Bexpress(); // only if the whole alternative is default initializable
+    Bexpress(const Bexpress& in);
+    Bexpress& operator=(const Bexpress& other);
+
+    static Bexpress BinOp(BinOp_left_type left, BinOp_op_type op, BinOp_right_type right);
+    static Bexpress UnaryOp(UnaryOp_op_type op, UnaryOp_right_type right);
+    static Bexpress Leaf(Leaf_value_type value);
+
+    e::kind which() const { return (e::kind)mLayout->which; }
+
+    template <class F>
+    auto check(const F& f) {
+        if (isBinOp()) { return f(*(Bexpress_BinOp*)this); }
+        if (isUnaryOp()) { return f(*(Bexpress_UnaryOp*)this); }
+        if (isLeaf()) { return f(*(Bexpress_Leaf*)this); }
+    }
+
+    bool isBinOp() const { return which() == e::BinOp; }
+    bool isUnaryOp() const { return which() == e::UnaryOp; }
+    bool isLeaf() const { return which() == e::Leaf; }
+
+    // Accessors for elements of all subtypes here
+    // But account for element name overlap and type differences...
+    // const BinOp_left_type& left() const {}
+    // const BinOp_op_type& op() const {}
+    // const BinOp_right_type& right() const {}
+    // const UnaryOp_op_type& op() const {}
+    // const UnaryOp_right_type& right() const {}
+    // const Leaf_value_type& value() const {}
+    Alternative::layout* getLayout() const { return mLayout; }
+private:
+    Alternative::layout *mLayout;
+};
+
+NamedTuple* Bexpress::BinOp_Type = NamedTuple::Make(
+    {TypeDetails<BinOp_left_type>::getType(), TypeDetails<BinOp_op_type>::getType(), TypeDetails<BinOp_right_type>::getType()},
+    {"left", "op", "right"}
+);
+NamedTuple* Bexpress::UnaryOp_Type = NamedTuple::Make(
+    {TypeDetails<UnaryOp_op_type>::getType(), TypeDetails<UnaryOp_right_type>::getType()},
+    {"op", "right"}
+);
+NamedTuple* Bexpress::Leaf_Type = NamedTuple::Make(
+    {TypeDetails<Leaf_value_type>::getType()},
+    {"value"}
+);
+
+class Bexpress_BinOp : public Bexpress {
+public:
+    static ConcreteAlternative* getType() {
+        static ConcreteAlternative* t = ConcreteAlternative::Make(A::getType(), e::BinOp);
+        return t;
+    }
+    static Alternative* getAlternative() { return Bexpress::getType(); }
+
+    Bexpress_BinOp() { 
+        getType()->constructor(
+            (instance_ptr)getLayout(),
+            [](instance_ptr p) {BinOp_Type->constructor(p);});
+    }
+    Bexpress_BinOp(BinOp_left_type left1, BinOp_op_type op1, BinOp_right_type right1) {
+        Bexpress_BinOp(); 
+        left() = left1;
+        op() = op1;
+        right() = right1;
+     }
+    Bexpress_BinOp(const Bexpress_BinOp& other) {
+        getType()->copy_constructor((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+    }
+    Bexpress_BinOp& operator=(const Bexpress_BinOp& other) {
+         getType()->assign((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+    }
+    ~Bexpress_BinOp() {
+        getType()->destroy((instance_ptr)getLayout());
+    }
+
+    BinOp_left_type& left() const { return *(BinOp_left_type*)(getLayout()->data); }
+    BinOp_op_type& op() const { return *(BinOp_op_type*)(getLayout()->data + BinOp_size1); }
+    BinOp_right_type& right() const { return *(BinOp_right_type*)(getLayout()->data + BinOp_size1 + BinOp_size2); }
+};
+
+class Bexpress_UnaryOp : public Bexpress {
+public:
+    static ConcreteAlternative* getType() {
+        static ConcreteAlternative* t = ConcreteAlternative::Make(A::getType(), e::UnaryOp);
+        return t;
+    }
+    static Alternative* getAlternative() { return Bexpress::getType(); }
+
+    Bexpress_UnaryOp() { 
+        getType()->constructor(
+            (instance_ptr)getLayout(),
+            [](instance_ptr p) {UnaryOp_Type->constructor(p);});
+    }
+    Bexpress_UnaryOp(UnaryOp_op_type op1, UnaryOp_right_type right1) {
+        Bexpress_UnaryOp(); 
+        op() = op1;
+        right() = right1;
+     }
+    Bexpress_UnaryOp(const Bexpress_UnaryOp& other) {
+        getType()->copy_constructor((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+    }
+    Bexpress_UnaryOp& operator=(const Bexpress_UnaryOp& other) {
+         getType()->assign((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+    }
+    ~Bexpress_UnaryOp() {
+        getType()->destroy((instance_ptr)getLayout());
+    }
+
+    UnaryOp_op_type& op() const { return *(UnaryOp_op_type*)(getLayout()->data); }
+    UnaryOp_right_type& right() const { return *(UnaryOp_right_type*)(getLayout()->data + UnaryOp_size1); }
+};
+
+class Bexpress_Leaf : public Bexpress {
+public:
+    static ConcreteAlternative* getType() {
+        static ConcreteAlternative* t = ConcreteAlternative::Make(A::getType(), e::Leaf);
+        return t;
+    }
+    static Alternative* getAlternative() { return Bexpress::getType(); }
+
+    Bexpress_Leaf() { 
+        getType()->constructor(
+            (instance_ptr)getLayout(),
+            [](instance_ptr p) {Leaf_Type->constructor(p);});
+    }
+    Bexpress_Leaf(Leaf_value_type value1) {
+        Bexpress_Leaf(); 
+        value() = value1;
+     }
+    Bexpress_Leaf(const Bexpress_Leaf& other) {
+        getType()->copy_constructor((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+    }
+    Bexpress_Leaf& operator=(const Bexpress_Leaf& other) {
+         getType()->assign((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+    }
+    ~Bexpress_Leaf() {
+        getType()->destroy((instance_ptr)getLayout());
+    }
+
+    Leaf_value_type& value() const { return *(Leaf_value_type*)(getLayout()->data); }
+};
+
+template <>
+class TypeDetails<Bexpress> {
+public:
+    static Type* getType() {
+        static Type* t = Bexpress::getType();
+        if (t->bytecount() != bytecount) {
+            throw std::runtime_error("somehow we have the wrong bytecount!");
+        }
+        return t;
+    }
+    static const uint64_t bytecount = sizeof(void*);
+};
+
+// Generated NamedTuple NamedTupleTwoStrings
 //    X=String
 //    Y=String
 class NamedTupleTwoStrings {
@@ -12,6 +369,16 @@ private:
     static const int size2 = sizeof(Y_type);
     uint8_t data[size1 + size2];
 public:
+    static NamedTuple* getType() {
+        static NamedTuple* t = NamedTuple::Make({
+                TypeDetails<NamedTupleTwoStrings::X_type>::getType(),
+                TypeDetails<NamedTupleTwoStrings::Y_type>::getType()
+            },{
+                "X",
+                "Y"
+            });
+        return t;
+        }
     NamedTupleTwoStrings& operator = (const NamedTupleTwoStrings& other) {
         X() = other.X();
         Y() = other.Y();
@@ -51,13 +418,7 @@ template <>
 class TypeDetails<NamedTupleTwoStrings> {
 public:
     static Type* getType() {
-        static Type* t = NamedTuple::Make({
-                TypeDetails<NamedTupleTwoStrings::X_type>::getType(),
-                TypeDetails<NamedTupleTwoStrings::Y_type>::getType()
-            },{
-                "X",
-                "Y"
-            });
+        static Type* t = NamedTupleTwoStrings::getType();
         if (t->bytecount() != bytecount) {
             throw std::runtime_error("somehow we have the wrong bytecount!");
         }
@@ -68,7 +429,81 @@ public:
         sizeof(NamedTupleTwoStrings::Y_type);
 };
 
-// "NamedTupleIntFloatDesc"
+// Generated NamedTuple Choice
+//    A=NamedTupleTwoStrings
+//    B=Bexpress
+class Choice {
+public:
+    typedef NamedTupleTwoStrings A_type;
+    typedef Bexpress B_type;
+    A_type& A() const { return *(A_type*)(data); }
+    B_type& B() const { return *(B_type*)(data + size1); }
+private:
+    static const int size1 = sizeof(A_type);
+    static const int size2 = sizeof(B_type);
+    uint8_t data[size1 + size2];
+public:
+    static NamedTuple* getType() {
+        static NamedTuple* t = NamedTuple::Make({
+                TypeDetails<Choice::A_type>::getType(),
+                TypeDetails<Choice::B_type>::getType()
+            },{
+                "A",
+                "B"
+            });
+        return t;
+        }
+    Choice& operator = (const Choice& other) {
+        A() = other.A();
+        B() = other.B();
+        return *this;
+    }
+
+    Choice(const Choice& other) {
+        new (&A()) A_type(other.A());
+        new (&B()) B_type(other.B());
+    }
+
+    ~Choice() {
+        B().~B_type();
+        A().~A_type();
+    }
+
+    Choice() {
+        bool initA = false;
+        bool initB = false;
+        try {
+            new (&A()) A_type();
+            initA = true;
+            new (&B()) B_type();
+            initB = true;
+        } catch(...) {
+            try {
+                if (initB) B().~B_type();
+                if (initA) A().~A_type();
+            } catch(...) {
+            }
+            throw;
+        }
+    }
+};
+
+template <>
+class TypeDetails<Choice> {
+public:
+    static Type* getType() {
+        static Type* t = Choice::getType();
+        if (t->bytecount() != bytecount) {
+            throw std::runtime_error("somehow we have the wrong bytecount!");
+        }
+        return t;
+    }
+    static const uint64_t bytecount = 
+        sizeof(Choice::A_type) +
+        sizeof(Choice::B_type);
+};
+
+// Generated NamedTuple NamedTupleIntFloatDesc
 //    a=OneOf<int64_t, double, bool>
 //    b=double
 //    desc=String
@@ -86,6 +521,18 @@ private:
     static const int size3 = sizeof(desc_type);
     uint8_t data[size1 + size2 + size3];
 public:
+    static NamedTuple* getType() {
+        static NamedTuple* t = NamedTuple::Make({
+                TypeDetails<NamedTupleIntFloatDesc::a_type>::getType(),
+                TypeDetails<NamedTupleIntFloatDesc::b_type>::getType(),
+                TypeDetails<NamedTupleIntFloatDesc::desc_type>::getType()
+            },{
+                "a",
+                "b",
+                "desc"
+            });
+        return t;
+        }
     NamedTupleIntFloatDesc& operator = (const NamedTupleIntFloatDesc& other) {
         a() = other.a();
         b() = other.b();
@@ -132,15 +579,7 @@ template <>
 class TypeDetails<NamedTupleIntFloatDesc> {
 public:
     static Type* getType() {
-        static Type* t = NamedTuple::Make({
-                TypeDetails<NamedTupleIntFloatDesc::a_type>::getType(),
-                TypeDetails<NamedTupleIntFloatDesc::b_type>::getType(),
-                TypeDetails<NamedTupleIntFloatDesc::desc_type>::getType()
-            },{
-                "a",
-                "b",
-                "desc"
-            });
+        static Type* t = NamedTupleIntFloatDesc::getType();
         if (t->bytecount() != bytecount) {
             throw std::runtime_error("somehow we have the wrong bytecount!");
         }
@@ -152,7 +591,7 @@ public:
         sizeof(NamedTupleIntFloatDesc::desc_type);
 };
 
-// "NamedTupleBoolListOfInt"
+// Generated NamedTuple NamedTupleBoolListOfInt
 //    X=bool
 //    Y=ListOf<int64_t>
 class NamedTupleBoolListOfInt {
@@ -166,6 +605,16 @@ private:
     static const int size2 = sizeof(Y_type);
     uint8_t data[size1 + size2];
 public:
+    static NamedTuple* getType() {
+        static NamedTuple* t = NamedTuple::Make({
+                TypeDetails<NamedTupleBoolListOfInt::X_type>::getType(),
+                TypeDetails<NamedTupleBoolListOfInt::Y_type>::getType()
+            },{
+                "X",
+                "Y"
+            });
+        return t;
+        }
     NamedTupleBoolListOfInt& operator = (const NamedTupleBoolListOfInt& other) {
         X() = other.X();
         Y() = other.Y();
@@ -205,13 +654,7 @@ template <>
 class TypeDetails<NamedTupleBoolListOfInt> {
 public:
     static Type* getType() {
-        static Type* t = NamedTuple::Make({
-                TypeDetails<NamedTupleBoolListOfInt::X_type>::getType(),
-                TypeDetails<NamedTupleBoolListOfInt::Y_type>::getType()
-            },{
-                "X",
-                "Y"
-            });
+        static Type* t = NamedTupleBoolListOfInt::getType();
         if (t->bytecount() != bytecount) {
             throw std::runtime_error("somehow we have the wrong bytecount!");
         }
@@ -222,7 +665,7 @@ public:
         sizeof(NamedTupleBoolListOfInt::Y_type);
 };
 
-// "NamedTupleAttrAndValues"
+// Generated NamedTuple NamedTupleAttrAndValues
 //    attributes=TupleOf<String>
 //    values=TupleOf<int64_t>
 class NamedTupleAttrAndValues {
@@ -236,6 +679,16 @@ private:
     static const int size2 = sizeof(values_type);
     uint8_t data[size1 + size2];
 public:
+    static NamedTuple* getType() {
+        static NamedTuple* t = NamedTuple::Make({
+                TypeDetails<NamedTupleAttrAndValues::attributes_type>::getType(),
+                TypeDetails<NamedTupleAttrAndValues::values_type>::getType()
+            },{
+                "attributes",
+                "values"
+            });
+        return t;
+        }
     NamedTupleAttrAndValues& operator = (const NamedTupleAttrAndValues& other) {
         attributes() = other.attributes();
         values() = other.values();
@@ -275,13 +728,7 @@ template <>
 class TypeDetails<NamedTupleAttrAndValues> {
 public:
     static Type* getType() {
-        static Type* t = NamedTuple::Make({
-                TypeDetails<NamedTupleAttrAndValues::attributes_type>::getType(),
-                TypeDetails<NamedTupleAttrAndValues::values_type>::getType()
-            },{
-                "attributes",
-                "values"
-            });
+        static Type* t = NamedTupleAttrAndValues::getType();
         if (t->bytecount() != bytecount) {
             throw std::runtime_error("somehow we have the wrong bytecount!");
         }

--- a/typed_python/GeneratedTypes.hpp
+++ b/typed_python/GeneratedTypes.hpp
@@ -1,7 +1,6 @@
-// Generated Alternative A
-//    A=
-//   Sub1=(b=int64_t, c=int64_t)
-//   Sub2=(d=String, e=String)
+// Generated Alternative A=
+//     Sub1=(b=int64_t, c=int64_t)
+//     Sub2=(d=String, e=String)
 
 class A_Sub1;
 class A_Sub2;
@@ -13,30 +12,16 @@ public:
     };
 
     static NamedTuple* Sub1_Type;
-    typedef int64_t Sub1_b_type;
-    typedef int64_t Sub1_c_type;
-    static const int Sub1_size1 = sizeof(Sub1_b_type);
-    static const int Sub1_size2 = sizeof(Sub1_c_type);
     static NamedTuple* Sub2_Type;
-    typedef String Sub2_d_type;
-    typedef String Sub2_e_type;
-    static const int Sub2_size1 = sizeof(Sub2_d_type);
-    static const int Sub2_size2 = sizeof(Sub2_e_type);
 
-    static Alternative* getType() {
-        static Alternative* t = Alternative::Make("A", {
-            {"Sub1", Sub1_Type},
-            {"Sub2", Sub2_Type}
-        }, {});
-        return t;
-    }
-    ~A();
-    A(); // only if the whole alternative is default initializable
-    A(const A& in);
-    A& operator=(const A& other);
+    static Alternative* getType();
+    ~A() { getType()->destroy((instance_ptr)&mLayout); }
+    A() { getType()->constructor((instance_ptr)&mLayout); }
+    A(const A& in) { getType()->copy_constructor((instance_ptr)&mLayout, (instance_ptr)&in.mLayout); }
+    A& operator=(const A& other) { getType()->assign((instance_ptr)&mLayout, (instance_ptr)&other.mLayout); return *this; }
 
-    static A Sub1(Sub1_b_type b, Sub1_c_type c);
-    static A Sub2(Sub2_d_type d, Sub2_e_type e);
+    static A Sub1(const int64_t& b, const int64_t& c);
+    static A Sub2(const String& d, const String& e);
 
     e::kind which() const { return (e::kind)mLayout->which; }
 
@@ -49,25 +34,57 @@ public:
     bool isSub1() const { return which() == e::Sub1; }
     bool isSub2() const { return which() == e::Sub2; }
 
-    // Accessors for elements of all subtypes here
-    // But account for element name overlap and type differences...
-    // const Sub1_b_type& b() const {}
-    // const Sub1_c_type& c() const {}
-    // const Sub2_d_type& d() const {}
-    // const Sub2_e_type& e() const {}
-    Alternative::layout* getLayout() const { return mLayout; }
-private:
+    // Accessors for members
+    const int64_t& b() const;
+    const int64_t& c() const;
+    const String& d() const;
+    const String& e() const;
+
+protected:
     Alternative::layout *mLayout;
 };
 
+template <>
+class TypeDetails<A*> {
+public:
+    static Type* getType() {
+        static Type* t = new Forward(0, "A");
+        return t;
+    }
+    static const uint64_t bytecount = sizeof(void*);
+};
+
 NamedTuple* A::Sub1_Type = NamedTuple::Make(
-    {TypeDetails<Sub1_b_type>::getType(), TypeDetails<Sub1_c_type>::getType()},
+    {TypeDetails<int64_t>::getType(), TypeDetails<int64_t>::getType()},
     {"b", "c"}
 );
+
 NamedTuple* A::Sub2_Type = NamedTuple::Make(
-    {TypeDetails<Sub2_d_type>::getType(), TypeDetails<Sub2_e_type>::getType()},
+    {TypeDetails<String>::getType(), TypeDetails<String>::getType()},
     {"d", "e"}
 );
+
+// static
+Alternative* A::getType() {
+    static Alternative* t = Alternative::Make("A", {
+        {"Sub1", Sub1_Type},
+        {"Sub2", Sub2_Type}
+    }, {});
+    return t;
+}
+
+template <>
+class TypeDetails<A> {
+public:
+    static Type* getType() {
+        static Type* t = A::getType();
+        if (t->bytecount() != bytecount) {
+            throw std::runtime_error("A somehow we have the wrong bytecount!");
+        }
+        return t;
+    }
+    static const uint64_t bytecount = sizeof(void*);
+};
 
 class A_Sub1 : public A {
 public:
@@ -79,27 +96,34 @@ public:
 
     A_Sub1() { 
         getType()->constructor(
-            (instance_ptr)getLayout(),
+            (instance_ptr)&mLayout,
             [](instance_ptr p) {Sub1_Type->constructor(p);});
     }
-    A_Sub1(Sub1_b_type b1, Sub1_c_type c1) {
+    A_Sub1( const int64_t& b1,  const int64_t& c1) {
         A_Sub1(); 
         b() = b1;
         c() = c1;
-     }
+    }
     A_Sub1(const A_Sub1& other) {
-        getType()->copy_constructor((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+        getType()->copy_constructor((instance_ptr)&mLayout, (instance_ptr)&other.mLayout);
     }
     A_Sub1& operator=(const A_Sub1& other) {
-         getType()->assign((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+         getType()->assign((instance_ptr)&mLayout, (instance_ptr)&other.mLayout);
+         return *this;
     }
     ~A_Sub1() {
-        getType()->destroy((instance_ptr)getLayout());
+        getType()->destroy((instance_ptr)&mLayout);
     }
 
-    Sub1_b_type& b() const { return *(Sub1_b_type*)(getLayout()->data); }
-    Sub1_c_type& c() const { return *(Sub1_c_type*)(getLayout()->data + Sub1_size1); }
+    int64_t& b() const { return *(int64_t*)(mLayout->data); }
+    int64_t& c() const { return *(int64_t*)(mLayout->data + size1); }
+private:
+    static const int size1 = sizeof(int64_t);
 };
+
+A A::Sub1(const int64_t& b, const int64_t& c) {
+    return A_Sub1(b, c);
+}
 
 class A_Sub2 : public A {
 public:
@@ -111,58 +135,65 @@ public:
 
     A_Sub2() { 
         getType()->constructor(
-            (instance_ptr)getLayout(),
+            (instance_ptr)&mLayout,
             [](instance_ptr p) {Sub2_Type->constructor(p);});
     }
-    A_Sub2(Sub2_d_type d1, Sub2_e_type e1) {
+    A_Sub2( const String& d1,  const String& e1) {
         A_Sub2(); 
         d() = d1;
         e() = e1;
-     }
+    }
     A_Sub2(const A_Sub2& other) {
-        getType()->copy_constructor((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+        getType()->copy_constructor((instance_ptr)&mLayout, (instance_ptr)&other.mLayout);
     }
     A_Sub2& operator=(const A_Sub2& other) {
-         getType()->assign((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+         getType()->assign((instance_ptr)&mLayout, (instance_ptr)&other.mLayout);
+         return *this;
     }
     ~A_Sub2() {
-        getType()->destroy((instance_ptr)getLayout());
+        getType()->destroy((instance_ptr)&mLayout);
     }
 
-    Sub2_d_type& d() const { return *(Sub2_d_type*)(getLayout()->data); }
-    Sub2_e_type& e() const { return *(Sub2_e_type*)(getLayout()->data + Sub2_size1); }
+    String& d() const { return *(String*)(mLayout->data); }
+    String& e() const { return *(String*)(mLayout->data + size1); }
+private:
+    static const int size1 = sizeof(String);
 };
 
-template <>
-class TypeDetails<A> {
-public:
-    static Type* getType() {
-        static Type* t = A::getType();
-        if (t->bytecount() != bytecount) {
-            throw std::runtime_error("somehow we have the wrong bytecount!");
-        }
-        return t;
-    }
-    static const uint64_t bytecount = sizeof(void*);
-};
+A A::Sub2(const String& d, const String& e) {
+    return A_Sub2(d, e);
+}
 
-class Bexpress;
+const int64_t& A::b() const {
+    if (isSub1())
+        return ((A_Sub1*)this)->b();
+    throw std::runtime_error("\"A\" subtype does not contain \"b\"");
+}
 
-template <>
-class TypeDetails<Bexpress*> {
-public:
-    static Type* getType() {
-        static Type* t = PointerTo::Make(Int64::Make());  // forward types are not actually constructed
-        return t;
-    }
-    static const uint64_t bytecount = sizeof(void*);
-};
+const int64_t& A::c() const {
+    if (isSub1())
+        return ((A_Sub1*)this)->c();
+    throw std::runtime_error("\"A\" subtype does not contain \"c\"");
+}
 
-// Generated Alternative Bexpress
-//    Bexpress=
-//   BinOp=(left=Bexpress*, op=String, right=Bexpress*)
-//   UnaryOp=(op=String, right=Bexpress*)
-//   Leaf=(value=bool)
+const String& A::d() const {
+    if (isSub2())
+        return ((A_Sub2*)this)->d();
+    throw std::runtime_error("\"A\" subtype does not contain \"d\"");
+}
+
+const String& A::e() const {
+    if (isSub2())
+        return ((A_Sub2*)this)->e();
+    throw std::runtime_error("\"A\" subtype does not contain \"e\"");
+}
+
+// END Generated Alternative A
+
+// Generated Alternative Bexpress=
+//     BinOp=(left=Bexpress, op=String, right=Bexpress)
+//     UnaryOp=(op=String, right=Bexpress)
+//     Leaf=(value=bool)
 
 class Bexpress_BinOp;
 class Bexpress_UnaryOp;
@@ -175,37 +206,18 @@ public:
     };
 
     static NamedTuple* BinOp_Type;
-    typedef Bexpress* BinOp_left_type;
-    typedef String BinOp_op_type;
-    typedef Bexpress* BinOp_right_type;
-    static const int BinOp_size1 = sizeof(BinOp_left_type);
-    static const int BinOp_size2 = sizeof(BinOp_op_type);
-    static const int BinOp_size3 = sizeof(BinOp_right_type);
     static NamedTuple* UnaryOp_Type;
-    typedef String UnaryOp_op_type;
-    typedef Bexpress* UnaryOp_right_type;
-    static const int UnaryOp_size1 = sizeof(UnaryOp_op_type);
-    static const int UnaryOp_size2 = sizeof(UnaryOp_right_type);
     static NamedTuple* Leaf_Type;
-    typedef bool Leaf_value_type;
-    static const int Leaf_size1 = sizeof(Leaf_value_type);
 
-    static Alternative* getType() {
-        static Alternative* t = Alternative::Make("Bexpress", {
-            {"BinOp", BinOp_Type},
-            {"UnaryOp", UnaryOp_Type},
-            {"Leaf", Leaf_Type}
-        }, {});
-        return t;
-    }
-    ~Bexpress();
-    Bexpress(); // only if the whole alternative is default initializable
-    Bexpress(const Bexpress& in);
-    Bexpress& operator=(const Bexpress& other);
+    static Alternative* getType();
+    ~Bexpress() { getType()->destroy((instance_ptr)&mLayout); }
+    Bexpress() { getType()->constructor((instance_ptr)&mLayout); }
+    Bexpress(const Bexpress& in) { getType()->copy_constructor((instance_ptr)&mLayout, (instance_ptr)&in.mLayout); }
+    Bexpress& operator=(const Bexpress& other) { getType()->assign((instance_ptr)&mLayout, (instance_ptr)&other.mLayout); return *this; }
 
-    static Bexpress BinOp(BinOp_left_type left, BinOp_op_type op, BinOp_right_type right);
-    static Bexpress UnaryOp(UnaryOp_op_type op, UnaryOp_right_type right);
-    static Bexpress Leaf(Leaf_value_type value);
+    static Bexpress BinOp(const Bexpress& left, const String& op, const Bexpress& right);
+    static Bexpress UnaryOp(const String& op, const Bexpress& right);
+    static Bexpress Leaf(const bool& value);
 
     e::kind which() const { return (e::kind)mLayout->which; }
 
@@ -220,31 +232,65 @@ public:
     bool isUnaryOp() const { return which() == e::UnaryOp; }
     bool isLeaf() const { return which() == e::Leaf; }
 
-    // Accessors for elements of all subtypes here
-    // But account for element name overlap and type differences...
-    // const BinOp_left_type& left() const {}
-    // const BinOp_op_type& op() const {}
-    // const BinOp_right_type& right() const {}
-    // const UnaryOp_op_type& op() const {}
-    // const UnaryOp_right_type& right() const {}
-    // const Leaf_value_type& value() const {}
-    Alternative::layout* getLayout() const { return mLayout; }
-private:
+    // Accessors for members
+    const Bexpress& left() const;
+    const String& op() const;
+    const Bexpress& right() const;
+    const bool& value() const;
+
+protected:
     Alternative::layout *mLayout;
 };
 
+template <>
+class TypeDetails<Bexpress*> {
+public:
+    static Type* getType() {
+        static Type* t = new Forward(0, "Bexpress");
+        return t;
+    }
+    static const uint64_t bytecount = sizeof(void*);
+};
+
 NamedTuple* Bexpress::BinOp_Type = NamedTuple::Make(
-    {TypeDetails<BinOp_left_type>::getType(), TypeDetails<BinOp_op_type>::getType(), TypeDetails<BinOp_right_type>::getType()},
+    {TypeDetails<Bexpress*>::getType(), TypeDetails<String>::getType(), TypeDetails<Bexpress*>::getType()},
     {"left", "op", "right"}
 );
+
 NamedTuple* Bexpress::UnaryOp_Type = NamedTuple::Make(
-    {TypeDetails<UnaryOp_op_type>::getType(), TypeDetails<UnaryOp_right_type>::getType()},
+    {TypeDetails<String>::getType(), TypeDetails<Bexpress*>::getType()},
     {"op", "right"}
 );
+
 NamedTuple* Bexpress::Leaf_Type = NamedTuple::Make(
-    {TypeDetails<Leaf_value_type>::getType()},
+    {TypeDetails<bool>::getType()},
     {"value"}
 );
+
+// static
+Alternative* Bexpress::getType() {
+    static Alternative* t = Alternative::Make("Bexpress", {
+        {"BinOp", BinOp_Type},
+        {"UnaryOp", UnaryOp_Type},
+        {"Leaf", Leaf_Type}
+    }, {});
+    BinOp_Type->directResolveForward(TypeDetails<Bexpress*>::getType(), t);
+    UnaryOp_Type->directResolveForward(TypeDetails<Bexpress*>::getType(), t);
+    return t;
+}
+
+template <>
+class TypeDetails<Bexpress> {
+public:
+    static Type* getType() {
+        static Type* t = Bexpress::getType();
+        if (t->bytecount() != bytecount) {
+            throw std::runtime_error("Bexpress somehow we have the wrong bytecount!");
+        }
+        return t;
+    }
+    static const uint64_t bytecount = sizeof(void*);
+};
 
 class Bexpress_BinOp : public Bexpress {
 public:
@@ -256,29 +302,37 @@ public:
 
     Bexpress_BinOp() { 
         getType()->constructor(
-            (instance_ptr)getLayout(),
+            (instance_ptr)&mLayout,
             [](instance_ptr p) {BinOp_Type->constructor(p);});
     }
-    Bexpress_BinOp(BinOp_left_type left1, BinOp_op_type op1, BinOp_right_type right1) {
+    Bexpress_BinOp( const Bexpress& left1,  const String& op1,  const Bexpress& right1) {
         Bexpress_BinOp(); 
         left() = left1;
         op() = op1;
         right() = right1;
-     }
+    }
     Bexpress_BinOp(const Bexpress_BinOp& other) {
-        getType()->copy_constructor((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+        getType()->copy_constructor((instance_ptr)&mLayout, (instance_ptr)&other.mLayout);
     }
     Bexpress_BinOp& operator=(const Bexpress_BinOp& other) {
-         getType()->assign((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+         getType()->assign((instance_ptr)&mLayout, (instance_ptr)&other.mLayout);
+         return *this;
     }
     ~Bexpress_BinOp() {
-        getType()->destroy((instance_ptr)getLayout());
+        getType()->destroy((instance_ptr)&mLayout);
     }
 
-    BinOp_left_type& left() const { return *(BinOp_left_type*)(getLayout()->data); }
-    BinOp_op_type& op() const { return *(BinOp_op_type*)(getLayout()->data + BinOp_size1); }
-    BinOp_right_type& right() const { return *(BinOp_right_type*)(getLayout()->data + BinOp_size1 + BinOp_size2); }
+    Bexpress& left() const { return *(Bexpress*)(mLayout->data); }
+    String& op() const { return *(String*)(mLayout->data + size1); }
+    Bexpress& right() const { return *(Bexpress*)(mLayout->data + size1 + size2); }
+private:
+    static const int size1 = sizeof(Bexpress);
+    static const int size2 = sizeof(String);
 };
+
+Bexpress Bexpress::BinOp(const Bexpress& left, const String& op, const Bexpress& right) {
+    return Bexpress_BinOp(left, op, right);
+}
 
 class Bexpress_UnaryOp : public Bexpress {
 public:
@@ -290,27 +344,34 @@ public:
 
     Bexpress_UnaryOp() { 
         getType()->constructor(
-            (instance_ptr)getLayout(),
+            (instance_ptr)&mLayout,
             [](instance_ptr p) {UnaryOp_Type->constructor(p);});
     }
-    Bexpress_UnaryOp(UnaryOp_op_type op1, UnaryOp_right_type right1) {
+    Bexpress_UnaryOp( const String& op1,  const Bexpress& right1) {
         Bexpress_UnaryOp(); 
         op() = op1;
         right() = right1;
-     }
+    }
     Bexpress_UnaryOp(const Bexpress_UnaryOp& other) {
-        getType()->copy_constructor((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+        getType()->copy_constructor((instance_ptr)&mLayout, (instance_ptr)&other.mLayout);
     }
     Bexpress_UnaryOp& operator=(const Bexpress_UnaryOp& other) {
-         getType()->assign((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+         getType()->assign((instance_ptr)&mLayout, (instance_ptr)&other.mLayout);
+         return *this;
     }
     ~Bexpress_UnaryOp() {
-        getType()->destroy((instance_ptr)getLayout());
+        getType()->destroy((instance_ptr)&mLayout);
     }
 
-    UnaryOp_op_type& op() const { return *(UnaryOp_op_type*)(getLayout()->data); }
-    UnaryOp_right_type& right() const { return *(UnaryOp_right_type*)(getLayout()->data + UnaryOp_size1); }
+    String& op() const { return *(String*)(mLayout->data); }
+    Bexpress& right() const { return *(Bexpress*)(mLayout->data + size1); }
+private:
+    static const int size1 = sizeof(String);
 };
+
+Bexpress Bexpress::UnaryOp(const String& op, const Bexpress& right) {
+    return Bexpress_UnaryOp(op, right);
+}
 
 class Bexpress_Leaf : public Bexpress {
 public:
@@ -322,38 +383,61 @@ public:
 
     Bexpress_Leaf() { 
         getType()->constructor(
-            (instance_ptr)getLayout(),
+            (instance_ptr)&mLayout,
             [](instance_ptr p) {Leaf_Type->constructor(p);});
     }
-    Bexpress_Leaf(Leaf_value_type value1) {
+    Bexpress_Leaf( const bool& value1) {
         Bexpress_Leaf(); 
         value() = value1;
-     }
+    }
     Bexpress_Leaf(const Bexpress_Leaf& other) {
-        getType()->copy_constructor((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+        getType()->copy_constructor((instance_ptr)&mLayout, (instance_ptr)&other.mLayout);
     }
     Bexpress_Leaf& operator=(const Bexpress_Leaf& other) {
-         getType()->assign((instance_ptr)getLayout(), (instance_ptr)other.getLayout());
+         getType()->assign((instance_ptr)&mLayout, (instance_ptr)&other.mLayout);
+         return *this;
     }
     ~Bexpress_Leaf() {
-        getType()->destroy((instance_ptr)getLayout());
+        getType()->destroy((instance_ptr)&mLayout);
     }
 
-    Leaf_value_type& value() const { return *(Leaf_value_type*)(getLayout()->data); }
+    bool& value() const { return *(bool*)(mLayout->data); }
+private:
 };
 
-template <>
-class TypeDetails<Bexpress> {
-public:
-    static Type* getType() {
-        static Type* t = Bexpress::getType();
-        if (t->bytecount() != bytecount) {
-            throw std::runtime_error("somehow we have the wrong bytecount!");
-        }
-        return t;
-    }
-    static const uint64_t bytecount = sizeof(void*);
-};
+Bexpress Bexpress::Leaf(const bool& value) {
+    return Bexpress_Leaf(value);
+}
+
+const Bexpress& Bexpress::left() const {
+    if (isBinOp())
+        return ((Bexpress_BinOp*)this)->left();
+    throw std::runtime_error("\"Bexpress\" subtype does not contain \"left\"");
+}
+
+const String& Bexpress::op() const {
+    if (isBinOp())
+        return ((Bexpress_BinOp*)this)->op();
+    if (isUnaryOp())
+        return ((Bexpress_UnaryOp*)this)->op();
+    throw std::runtime_error("\"Bexpress\" subtype does not contain \"op\"");
+}
+
+const Bexpress& Bexpress::right() const {
+    if (isBinOp())
+        return ((Bexpress_BinOp*)this)->right();
+    if (isUnaryOp())
+        return ((Bexpress_UnaryOp*)this)->right();
+    throw std::runtime_error("\"Bexpress\" subtype does not contain \"right\"");
+}
+
+const bool& Bexpress::value() const {
+    if (isLeaf())
+        return ((Bexpress_Leaf*)this)->value();
+    throw std::runtime_error("\"Bexpress\" subtype does not contain \"value\"");
+}
+
+// END Generated Alternative Bexpress
 
 // Generated NamedTuple NamedTupleTwoStrings
 //    X=String
@@ -420,7 +504,7 @@ public:
     static Type* getType() {
         static Type* t = NamedTupleTwoStrings::getType();
         if (t->bytecount() != bytecount) {
-            throw std::runtime_error("somehow we have the wrong bytecount!");
+            throw std::runtime_error("NamedTupleTwoStrings somehow we have the wrong bytecount!");
         }
         return t;
     }
@@ -494,7 +578,7 @@ public:
     static Type* getType() {
         static Type* t = Choice::getType();
         if (t->bytecount() != bytecount) {
-            throw std::runtime_error("somehow we have the wrong bytecount!");
+            throw std::runtime_error("Choice somehow we have the wrong bytecount!");
         }
         return t;
     }
@@ -581,7 +665,7 @@ public:
     static Type* getType() {
         static Type* t = NamedTupleIntFloatDesc::getType();
         if (t->bytecount() != bytecount) {
-            throw std::runtime_error("somehow we have the wrong bytecount!");
+            throw std::runtime_error("NamedTupleIntFloatDesc somehow we have the wrong bytecount!");
         }
         return t;
     }
@@ -656,7 +740,7 @@ public:
     static Type* getType() {
         static Type* t = NamedTupleBoolListOfInt::getType();
         if (t->bytecount() != bytecount) {
-            throw std::runtime_error("somehow we have the wrong bytecount!");
+            throw std::runtime_error("NamedTupleBoolListOfInt somehow we have the wrong bytecount!");
         }
         return t;
     }
@@ -730,7 +814,7 @@ public:
     static Type* getType() {
         static Type* t = NamedTupleAttrAndValues::getType();
         if (t->bytecount() != bytecount) {
-            throw std::runtime_error("somehow we have the wrong bytecount!");
+            throw std::runtime_error("NamedTupleAttrAndValues somehow we have the wrong bytecount!");
         }
         return t;
     }

--- a/typed_python/_types.cpp
+++ b/typed_python/_types.cpp
@@ -30,6 +30,7 @@
 #include "DeserializationBuffer.hpp"
 #include "PythonSerializationContext.hpp"
 #include "UnicodeProps.hpp"
+#include "DirectTypesTest.hpp"
 
 
 PyObject *MakeTupleOrListOfType(PyObject* nullValue, PyObject* args, bool isTuple) {
@@ -819,6 +820,11 @@ PyObject *deserialize(PyObject* nullValue, PyObject* args) {
     }
 }
 
+PyObject *cpp_tests(PyObject* nullValue, PyObject* args) {
+    std::cerr << __FUNCTION__ << std::endl;
+    return incref(direct_cpp_tests() ? Py_True : Py_False);
+}
+
 PyObject *isSimple(PyObject* nullValue, PyObject* args) {
     if (PyTuple_Size(args) != 1) {
         PyErr_SetString(PyExc_TypeError, "isSimple takes 1 positional argument");
@@ -1123,6 +1129,7 @@ static PyMethodDef module_methods[] = {
     {"disableNativeDispatch", (PyCFunction)disableNativeDispatch, METH_VARARGS, NULL},
     {"enableNativeDispatch", (PyCFunction)enableNativeDispatch, METH_VARARGS, NULL},
     {"refcount", (PyCFunction)refcount, METH_VARARGS, NULL},
+    {"cpp_tests", (PyCFunction)cpp_tests, METH_VARARGS, NULL},
     {NULL, NULL}
 };
 

--- a/typed_python/all.cpp
+++ b/typed_python/all.cpp
@@ -56,4 +56,6 @@ compile the entire group all at once.
 #include "TupleOrListOfType.cpp"
 #include "Type.cpp"
 
+#include "DirectTypesTest.cpp"
+
 

--- a/typed_python/direct_types_test.py
+++ b/typed_python/direct_types_test.py
@@ -1,0 +1,22 @@
+import sys
+import argparse
+# from typed_python._types import resolveForwards
+from typed_python._types import cpp_tests
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description='Test cpp code in module')
+    parser.add_argument('-t', '--test', action='store_true')
+    args = parser.parse_args()
+    ret = 0
+
+    if args.test:
+        try:
+            ret = cpp_tests()
+        except Exception:
+            return 1
+    return ret
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/typed_python/generate_types.py
+++ b/typed_python/generate_types.py
@@ -1,7 +1,7 @@
 import sys
 import argparse
 from typed_python._types import NamedTuple
-from typed_python._types import ListOf, TupleOf, OneOf
+from typed_python._types import ListOf, TupleOf, OneOf, Alternative
 
 
 def gen_named_tuple_type(name, **kwargs):
@@ -9,90 +9,240 @@ def gen_named_tuple_type(name, **kwargs):
     keys = kwargs.keys()
     revkeys = list(keys)[::-1]
     ret = []
-    ret.append(f'// "{name}"')
+    ret.append(f'// Generated NamedTuple {name}')
     for key, value in items:
-        ret.append(f"//    {key}={value}")
+        ret.append(f'//    {key}={value}')
 
-    ret.append(f"class {name} {{")
-    ret.append("public:")
+    ret.append(f'class {name} {{')
+    ret.append('public:')
     for key, value in items:
-        ret.append(f"    typedef {value} {key}_type;")
-    count = 1
-    for key, value in items:
-        offset = ""
-        if count > 1:
-            offset = " + " + " + ".join(["size" + str(i) for i in range(1, count)])
-        ret.append(f"    {key}_type& {key}() const {{ return *({key}_type*)(data{offset}); }}")
-        count += 1
-    ret.append("private:")
-    count = 1
-    for key in keys:
-        ret.append(f"    static const int size{count} = sizeof({key}_type);")
-        count += 1
-    total = count
-    ret.append("    uint8_t data[{}];".format(" + ".join(["size" + str(i) for i in range(1, total)])))
-    ret.append("public:")
-
-    ret.append(f"    {name}& operator = (const {name}& other) {{")
-    for key in keys:
-        ret.append(f"        {key}() = other.{key}();")
-    ret.append("        return *this;")
-    ret.append("    }")
-    ret.append("")
-
-    ret.append(f"    {name}(const {name}& other) {{")
-    for key in keys:
-        ret.append(f"        new (&{key}()) {key}_type(other.{key}());")
-    ret.append("    }")
-    ret.append("")
-
-    ret.append(f"    ~{name}() {{")
-    for key in revkeys:
-        ret.append(f"        {key}().~{key}_type();")
-    ret.append("    }")
-    ret.append("")
-
-    ret.append(f"    {name}() {{")
-    for key in keys:
-        ret.append(f"        bool init{key} = false;")
-    ret.append("        try {")
-    for key in keys:
-        ret.append(f"            new (&{key}()) {key}_type();")
-        ret.append(f"            init{key} = true;")
-    ret.append("        } catch(...) {")
-    ret.append("            try {")
-    for key in revkeys:
-        ret.append(f"                if (init{key}) {key}().~{key}_type();")
-    ret.append("            } catch(...) {")
-    ret.append("            }")
-    ret.append("            throw;")
-    ret.append("        }")
-    ret.append("    }")
-    ret.append("};")
-    ret.append("")
-
-    ret.append("template <>")
-    ret.append(f"class TypeDetails<{name}> {{")
-    ret.append("public:")
-    ret.append("    static Type* getType() {")
-    ret.append("        static Type* t = NamedTuple::Make({")
-    ret.append(",\n".join(
-        [f"                TypeDetails<{name}::{key}_type>::getType()" for key in keys]))
-    ret.append("            },{")
-    ret.append(",\n".join(
+        ret.append(f'    typedef {value} {key}_type;')
+    for i, (key, value) in enumerate(items):
+        offset = '' if i == 0 else ' + ' + ' + '.join([f'size' + str(j) for j in range(1, i + 1)])
+        ret.append(f'    {key}_type& {key}() const {{ return *({key}_type*)(data{offset}); }}')
+    ret.append('private:')
+    for i, key in enumerate(keys):
+        ret.append(f'    static const int size{i + 1} = sizeof({key}_type);')
+    ret.append('    uint8_t data[{}];'.format(' + '.join(['size' + str(i) for i in range(1, len(keys) + 1)])))
+    ret.append('public:')
+    ret.append('    static NamedTuple* getType() {')
+    ret.append('        static NamedTuple* t = NamedTuple::Make({')
+    ret.append(',\n'.join(
+        [f'                TypeDetails<{name}::{key}_type>::getType()' for key in keys]))
+    ret.append('            },{')
+    ret.append(',\n'.join(
         [f'                "{key}"' for key in keys]))
-    ret.append("            });")
-    ret.append("        if (t->bytecount() != bytecount) {")
-    ret.append('            throw std::runtime_error("somehow we have the wrong bytecount!");')
-    ret.append("        }")
-    ret.append("        return t;")
-    ret.append("    }")
-    ret.append("    static const uint64_t bytecount = ")
-    ret.append(" +\n". join([f"        sizeof({name}::{key}_type)" for key in keys]) + ";")
-    ret.append("};")
-    ret.append("")
+    ret.append('            });')
+    ret.append('        return t;')
+    ret.append('        }')
 
-    return [e + "\n" for e in ret]
+    ret.append(f'    {name}& operator = (const {name}& other) {{')
+    for key in keys:
+        ret.append(f'        {key}() = other.{key}();')
+    ret.append('        return *this;')
+    ret.append('    }')
+    ret.append('')
+
+    ret.append(f'    {name}(const {name}& other) {{')
+    for key in keys:
+        ret.append(f'        new (&{key}()) {key}_type(other.{key}());')
+    ret.append('    }')
+    ret.append('')
+
+    ret.append(f'    ~{name}() {{')
+    for key in revkeys:
+        ret.append(f'        {key}().~{key}_type();')
+    ret.append('    }')
+    ret.append('')
+
+    ret.append(f'    {name}() {{')
+    for key in keys:
+        ret.append(f'        bool init{key} = false;')
+    ret.append('        try {')
+    for key in keys:
+        ret.append(f'            new (&{key}()) {key}_type();')
+        ret.append(f'            init{key} = true;')
+    ret.append('        } catch(...) {')
+    ret.append('            try {')
+    for key in revkeys:
+        ret.append(f'                if (init{key}) {key}().~{key}_type();')
+    ret.append('            } catch(...) {')
+    ret.append('            }')
+    ret.append('            throw;')
+    ret.append('        }')
+    ret.append('    }')
+    ret.append('};')
+    ret.append('')
+
+    ret.append('template <>')
+    ret.append(f'class TypeDetails<{name}> {{')
+    ret.append('public:')
+    ret.append('    static Type* getType() {')
+    ret.append(f'        static Type* t = {name}::getType();')
+    ret.append('        if (t->bytecount() != bytecount) {')
+    ret.append('            throw std::runtime_error("somehow we have the wrong bytecount!");')
+    ret.append('        }')
+    ret.append('        return t;')
+    ret.append('    }')
+    ret.append('    static const uint64_t bytecount = ')
+    ret.append(' +\n'. join([f'        sizeof({name}::{key}_type)' for key in keys]) + ';')
+    ret.append('};')
+    ret.append('')
+
+    return [e + '\n' for e in ret]
+
+
+# d is dictionary subtype->named_tuple,
+# where named_tuple is represented as [(param, type),...]
+def gen_alternative_type(name, d):
+    nts = d.keys()
+    ret = []
+    ret.append(f'// Generated Alternative {name}')
+    ret.append(f'//    {name}=')
+    for nt in nts:
+        ret.append('//   {}=({})'.format(nt, ", ".join([f'{a}={t}' for a, t in d[nt]])))
+    ret.append('')
+    for nt in nts:
+        ret.append(f'class {name}_{nt};')
+    ret.append('')
+    ret.append(f'class {name} {{')
+    ret.append('public:')
+    ret.append('    struct e {')
+    ret.append('        enum kind {{ {} }};'.format(
+        ", ".join([f'{nt}={i}' for i, nt in enumerate(nts)])))
+    ret.append('    };')
+    ret.append('')
+    for nt in nts:
+        ret.append(f'    static NamedTuple* {nt}_Type;')
+        for a, t in d[nt]:
+            ret.append(f'    typedef {t} {nt}_{a}_type;')
+        for i, (a, _) in enumerate(d[nt]):
+            ret.append(f'    static const int {nt}_size{i+1} = sizeof({nt}_{a}_type);')
+    ret.append('')
+    ret.append('    static Alternative* getType() {')
+    ret.append(f'        static Alternative* t = Alternative::Make("{name}", {{')
+    ret.append(f',\n'.join([f'            {{"{nt}", {nt}_Type}}' for nt in nts]))
+    ret.append('        }, {});')
+    ret.append('        return t;')
+    ret.append('    }')
+    ret.append(f'    ~{name}();')
+    ret.append(f'    {name}(); // only if the whole alternative is default initializable')
+    ret.append(f'    {name}(const {name}& in);')
+    ret.append(f'    {name}& operator=(const {name}& other);')
+    ret.append('')
+    for nt in nts:
+        ret.append(f'    static {name} {nt}('
+                   + ", ".join([f'{nt}_{a}_type {a}' for a, _ in d[nt]])
+                   + ');')
+    ret.append('')
+    ret.append('    e::kind which() const { return (e::kind)mLayout->which; }')
+    ret.append('')
+    ret.append('    template <class F>')
+    ret.append('    auto check(const F& f) {')
+    for nt in nts:
+        ret.append(f'        if (is{nt}()) {{ return f(*({name}_{nt}*)this); }}')
+    ret.append('    }')
+    ret.append('')
+    for nt in nts:
+        ret.append(f'    bool is{nt}() const {{ return which() == e::{nt}; }}')
+    ret.append('')
+    ret.append('    // Accessors for elements of all subtypes here')
+    ret.append('    // But account for element name overlap and type differences...')
+    for nt in nts:
+        for a, _ in d[nt]:
+            ret.append(f'    // const {nt}_{a}_type& {a}() const {{}}')
+    ret.append('    Alternative::layout* getLayout() const { return mLayout; }')
+    ret.append('private:')
+    ret.append('    Alternative::layout *mLayout;')
+    ret.append('};')
+    ret.append('')
+    for nt in nts:
+        ret.append(f'NamedTuple* {name}::{nt}_Type = NamedTuple::Make(')
+        ret.append('    {' + ", ".join([f'TypeDetails<{nt}_{a}_type>::getType()' for a, _ in d[nt]]) + '},')
+        ret.append('    {' + ", ".join([f'"{a}"' for a, _ in d[nt]]) + '}')
+        ret.append(');')
+    ret.append('')
+    for nt in nts:
+        ret.append(f'class {name}_{nt} : public {name} {{')
+        ret.append('public:')
+        ret.append('    static ConcreteAlternative* getType() {')
+        ret.append(f'        static ConcreteAlternative* t = ConcreteAlternative::Make(A::getType(), e::{nt});')
+        ret.append('        return t;')
+        ret.append('    }')
+        ret.append(f'    static Alternative* getAlternative() {{ return {name}::getType(); }}')
+        # ret.append(f'    static NamedTuple* elementType() {{ return {nt}_Type; }}')
+        ret.append('')
+        ret.append(f'    {name}_{nt}() {{ ')
+        ret.append('        getType()->constructor(')
+        ret.append('            (instance_ptr)getLayout(),')
+        ret.append(f'            [](instance_ptr p) {{{nt}_Type->constructor(p);}});')
+        ret.append('    }')
+        ret.append(f'    {name}_{nt}('
+                   + ", ".join([f'{nt}_{a}_type {a}1' for a, _ in d[nt]])
+                   + f') {{')
+        ret.append(f'        {name}_{nt}(); ')
+        for a, _ in d[nt]:
+            ret.append(f'        {a}() = {a}1;')
+        ret.append('     }')
+        ret.append(f'    {name}_{nt}(const {name}_{nt}& other) {{')
+        ret.append(f'        getType()->copy_constructor((instance_ptr)getLayout(), '
+                   '(instance_ptr)other.getLayout());')
+        ret.append('    }')
+        ret.append(f'    {name}_{nt}& operator=(const {name}_{nt}& other) {{')
+        ret.append('         getType()->assign((instance_ptr)getLayout(), (instance_ptr)other.getLayout());')
+        ret.append('    }')
+        ret.append(f'    ~{name}_{nt}() {{')
+        ret.append(f'        getType()->destroy((instance_ptr)getLayout());')
+        ret.append('    }')
+        ret.append('')
+        for i, (a, _) in enumerate(d[nt]):
+            offset = '' if i == 0 else ' + ' + ' + '.join([f'{nt}_size' + str(j) for j in range(1, i+1)])
+            ret.append(f'    {nt}_{a}_type& {a}() const {{ return *({nt}_{a}_type*)(getLayout()->data{offset}); }}')
+        ret.append('};')
+        ret.append('')
+    ret.append('template <>')
+    ret.append(f'class TypeDetails<{name}> {{')
+    ret.append('public:')
+    ret.append('    static Type* getType() {')
+    ret.append(f'        static Type* t = {name}::getType();')
+    ret.append('        if (t->bytecount() != bytecount) {')
+    ret.append('            throw std::runtime_error("somehow we have the wrong bytecount!");')
+    ret.append('        }')
+    ret.append('        return t;')
+    ret.append('    }')
+    ret.append('    static const uint64_t bytecount = sizeof(void*);')
+    ret.append('};')
+    ret.append('')
+    return [e + '\n' for e in ret]
+
+
+fwd_decls = set()
+
+
+def gen_forward_declarations(element_types):
+    ret = []
+    for t in element_types:
+        if t.__typed_python_category__ == 'Forward':
+            forward_type_name = str(t)[8:-2]    # just for now!
+            if forward_type_name not in fwd_decls:
+                fwd_decls.add(forward_type_name)
+                ret.append(f"class {forward_type_name};")
+                ret.append("")
+                ret.append('template <>')
+                ret.append(f'class TypeDetails<{forward_type_name}*> {{')
+                ret.append('public:')
+                ret.append('    static Type* getType() {')
+                ret.append('        static Type* t = PointerTo::Make(Int64::Make());  '
+                           '// forward types are not actually constructed')
+                ret.append('        return t;')
+                ret.append('    }')
+                ret.append('    static const uint64_t bytecount = sizeof(void*);')
+                ret.append('};')
+                ret.append('')
+    return [e + '\n' for e in ret]
+
+
+cpp_type_mapping = dict()
 
 
 # py type -> c++ direct type
@@ -105,36 +255,40 @@ def gen_named_tuple_type(name, **kwargs):
 # Either assume Arb is defined in a previous stage, or keep track of it
 def cpp_type(py_type):
     simple_cats = {
-        "Int64": "int64_t",
-        "UInt64": "uint64_t",
-        "Int32": "uint32_t",
-        "UInt32": "uint32_t",
-        "Int16": "uint16_t",
-        "UInt16": "uint16_t",
-        "Int8": "uint8_t",
-        "UInt8": "uint8_t",
-        "Bool": "bool",
-        "Float64": "double",
-        "Float32": "float",
-        "String": "String"
+        'Int64': 'int64_t',
+        'UInt64': 'uint64_t',
+        'Int32': 'uint32_t',
+        'UInt32': 'uint32_t',
+        'Int16': 'uint16_t',
+        'UInt16': 'uint16_t',
+        'Int8': 'uint8_t',
+        'UInt8': 'uint8_t',
+        'Bool': 'bool',
+        'Float64': 'double',
+        'Float32': 'float',
+        'String': 'String'
     }
     cat = py_type.__typed_python_category__
     if cat in simple_cats.keys():
         return simple_cats[cat]
     # if cat == 'NamedTuple': # not supported
-    #     return "NamedTuple({})".format(
-    #         ", ".join(["{}={}".format(n,cpp_type(t))
+    #     return 'NamedTuple({})'.format(
+    #         ', '.join(['{}={}'.format(n,cpp_type(t))
     #             for n, t in zip(py_type.ElementNames, py_type.ElementTypes)])
     #         )
     if cat == 'NoneType':
-        return "None"
+        return 'None'
     if cat == 'ListOf' or cat == 'TupleOf':
-        return "{}<{}>".format(cat, cpp_type(py_type.ElementType))
+        return '{}<{}>'.format(cat, cpp_type(py_type.ElementType))
     if cat == 'OneOf':
-        return "OneOf<{}>".format(
-            ", ".join([cpp_type(t) for t in py_type.Types])
+        return 'OneOf<{}>'.format(
+            ', '.join([cpp_type(t) for t in py_type.Types])
         )
-    return "undefined type"
+    if cat == 'Forward':
+        return str(py_type)[8:-2] + '*'  # just for now! no forward resolution
+    if cat == 'NamedTuple' or cat == 'Alternative':
+        return cpp_type_mapping[py_type]
+    return 'undefined_type'
 
 
 def typed_python_codegen(**kwargs):
@@ -142,13 +296,41 @@ def typed_python_codegen(**kwargs):
     for k, v in kwargs.items():
         if v.__typed_python_category__ == 'NamedTuple':
             ret += gen_named_tuple_type(k, **{n: cpp_type(t) for n, t in zip(v.ElementNames, v.ElementTypes)})
+            cpp_type_mapping[v] = k
+        elif v.__typed_python_category__ == 'Alternative':
+            for e in v.__typed_python_alternatives__:
+                ret += gen_forward_declarations(e.ElementType.ElementTypes)
+            d = {nt.Name:
+                 [(a, cpp_type(t)) for a, t in zip(nt.ElementType.ElementNames, nt.ElementType.ElementTypes)]
+                 for nt in v.__typed_python_alternatives__ }
+            ret += gen_alternative_type(k, d)
+            cpp_type_mapping[v] = k
     return ret
 
 
 def GenerateTestTypes(dest):
-    with open(dest, "w") as f:
+    Bexpress = lambda: Bexpress
+    Bexpress = Alternative(
+        "BooleanExpr",
+        BinOp={
+            "left": Bexpress,
+            "op": str,
+            "right": Bexpress,
+        },
+        UnaryOp={
+            "op": str,
+            "right": Bexpress
+        },
+        Leaf={
+            "value": bool
+        }
+    )
+    with open(dest, 'w') as f:
         f.writelines(typed_python_codegen(
+            A=Alternative( 'A', Sub1={'b': int, 'c': int}, Sub2={'d': str, 'e': str} ),
+            Bexpress=Bexpress,
             NamedTupleTwoStrings=NamedTuple(X=str, Y=str),
+            Choice=NamedTuple(A=NamedTuple(X=str, Y=str), B=Bexpress),
             NamedTupleIntFloatDesc=NamedTuple(a=OneOf(int, float, bool), b=float, desc=str),
             NamedTupleBoolListOfInt=NamedTuple(X=bool, Y=ListOf(int)),
             NamedTupleAttrAndValues=NamedTuple(attributes=TupleOf(str), values=TupleOf(int))
@@ -169,5 +351,5 @@ def main(argv):
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     sys.exit(main(sys.argv))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Work towards c++ direct type corresponding to Alternative.
Attempt to handle self-references for Alternative types (but not other types of forward references)
For review.
Not complete.
Fixed OneOf template implementation.
Also, create rudimentary c++ test infrastructure, and tests for String, ListOf<>, TupleOf<>,  Dict<>, and OneOf<> types, correct bugs, and fill in any missing methods.


## Approach
In the representation of an Alternative instance in c++, if a named tuple refers to the Alternative type, it is a forward reference that is resolved when the Type of the Alternative instance is calculated.

C++ tests have a single entry point cpp_tests().  Run these tests with "make cpptests".

## How Has This Been Tested?
If this is the correct approach, need to create tests for Alternative.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.