### PR TITLE
WaitFor Test

### DIFF
--- a/object_database/service_manager/ServiceManager.py
+++ b/object_database/service_manager/ServiceManager.py
@@ -165,7 +165,7 @@ class ServiceManager(object):
                 return True
 
             instances = service_schema.ServiceInstance.lookupAll(service=service)
-            if any(inst.isActive() for inst in instances):
+            if any(not inst.isNotActive() for inst in instances):
                 return False
             return True
 

--- a/object_database/test_util.py
+++ b/object_database/test_util.py
@@ -110,7 +110,7 @@ def start_service_manager(tempDirectoryName, port, auth_token, loglevel_name="IN
     if not verbose:
         kwargs = dict(stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     else:
-        kwargs = dict()
+        kwargs = dict(stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     server = subprocess.Popen(
         [
@@ -130,9 +130,14 @@ def start_service_manager(tempDirectoryName, port, auth_token, loglevel_name="IN
     except subprocess.TimeoutExpired:
         pass
     else:
-        raise Exception(
-            f"Failed to start service_manager (retcode:{server.returncode})"
-        )
+        msg = f"Failed to start service_manager (retcode:{server.returncode})"
+
+        if verbose:
+            error = b''.join(server.stderr.readlines())
+            msg += "\n" + error.decode("utf-8")
+
+        raise Exception(msg)
+
     return server
 
 


### PR DESCRIPTION
## Motivation and Context
ServiceManager's `waitRunning` and `waitStopped` methods had no tests, and `waitStopped` was not checking the right thing. This PR fixes that bug and adds a test for both these methods.


## Approach
`not inst.isNotActive() != inst.isActive()`. We were using the 2nd form, but the first one is the correct for the check in `waitStopped`.  

## How Has This Been Tested?
The new unit-test, tests both `waitRunning` and `waitStopped`. It passes with the fix to `waitStopped` but it would fail before this change.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.